### PR TITLE
feat: filter test execution by test plan case IDs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,15 @@
+# qase-java 4.0.4
+
+## What's new
+
+Implemented support for running only the tests included in a test plan for Junit5 reporter.  
+To enable this feature, specify the test plan ID in the reporter configuration.  
+You can set it either in the `qase.config.json` file or through the `QASE_TESTOPS_PLAN_ID` environment variable.
+
 # qase-java 4.0.3
 
 ## What's new
 
-Implemented support for running only the tests included in a test plan.  
+Implemented support for running only the tests included in a test plan for TestNG reporter.  
 To enable this feature, specify the test plan ID in the reporter configuration.  
 You can set it either in the `qase.config.json` file or through the `QASE_TESTOPS_PLAN_ID` environment variable.

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.qase</groupId>
     <artifactId>qase-java</artifactId>
     <packaging>pom</packaging>
-    <version>4.0.3</version>
+    <version>4.0.4</version>
     <modules>
         <module>qase-java-commons</module>
         <module>qase-api-client</module>
@@ -35,7 +35,7 @@
         <junit4.version>4.13.1</junit4.version>
         <testng.version>7.1.0</testng.version>
         <unirest-java.version>3.4.00</unirest-java.version>
-        <junit-platform-engine.version>1.6.2</junit-platform-engine.version>
+        <junit-platform-engine.version>1.9.0</junit-platform-engine.version>
         <logback.version>1.2.13</logback.version>
         <slf4j-api.version>1.7.32</slf4j-api.version>
         <cucumber3-java.version>3.0.2</cucumber3-java.version>

--- a/qase-api-client/pom.xml
+++ b/qase-api-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.3</version>
+        <version>4.0.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-api-v2-client/pom.xml
+++ b/qase-api-v2-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.qase</groupId>
         <artifactId>qase-java</artifactId>
-        <version>4.0.3</version>
+        <version>4.0.4</version>
     </parent>
 
     <artifactId>qase-api-v2-client</artifactId>

--- a/qase-cucumber-v3-reporter/pom.xml
+++ b/qase-cucumber-v3-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.3</version>
+        <version>4.0.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v4-reporter/pom.xml
+++ b/qase-cucumber-v4-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.3</version>
+        <version>4.0.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v5-reporter/pom.xml
+++ b/qase-cucumber-v5-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.3</version>
+        <version>4.0.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v6-reporter/pom.xml
+++ b/qase-cucumber-v6-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.3</version>
+        <version>4.0.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v7-reporter/pom.xml
+++ b/qase-cucumber-v7-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.3</version>
+        <version>4.0.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-java-commons/pom.xml
+++ b/qase-java-commons/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.qase</groupId>
         <artifactId>qase-java</artifactId>
-        <version>4.0.3</version>
+        <version>4.0.4</version>
     </parent>
 
     <artifactId>qase-java-commons</artifactId>

--- a/qase-junit4-reporter/pom.xml
+++ b/qase-junit4-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.3</version>
+        <version>4.0.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-junit5-reporter/pom.xml
+++ b/qase-junit5-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.3</version>
+        <version>4.0.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-junit5-reporter/src/main/java/io/qase/junit5/Junit5PostDiscoveryFilter.java
+++ b/qase-junit5-reporter/src/main/java/io/qase/junit5/Junit5PostDiscoveryFilter.java
@@ -1,0 +1,50 @@
+package io.qase.junit5;
+
+import io.qase.commons.reporters.CoreReporterFactory;
+import org.junit.platform.engine.FilterResult;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.TestSource;
+import org.junit.platform.engine.support.descriptor.MethodSource;
+import org.junit.platform.launcher.PostDiscoveryFilter;
+
+import java.util.List;
+import java.util.Optional;
+
+import static io.qase.commons.utils.IntegrationUtils.*;
+
+public class Junit5PostDiscoveryFilter implements PostDiscoveryFilter {
+    private final List<Long> caseIds;
+
+    public Junit5PostDiscoveryFilter() {
+        this.caseIds = CoreReporterFactory.getInstance().getTestCaseIdsForExecution();
+    }
+
+    @Override
+    public FilterResult apply(TestDescriptor testDescriptor) {
+        if (this.caseIds.isEmpty()) {
+            return FilterResult.includedIf(true);
+        }
+
+        if (!testDescriptor.getChildren().isEmpty()) {
+            return FilterResult.included("filter only applied for tests");
+        }
+
+        final Optional<TestSource> testSource = testDescriptor.getSource();
+        if (!testSource.isPresent()) {
+            return FilterResult.includedIf(false);
+        }
+
+        final MethodSource methodSource = (MethodSource) testSource.get();
+        Long id = getCaseId(methodSource.getJavaMethod());
+
+        if (id == null) {
+            return FilterResult.includedIf(false);
+        }
+
+        if (this.caseIds.contains(id)) {
+            return FilterResult.includedIf(true);
+        }
+
+        return FilterResult.includedIf(false);
+    }
+}

--- a/qase-junit5-reporter/src/main/resources/META-INF/services/org.junit.platform.launcher.PostDiscoveryFilter
+++ b/qase-junit5-reporter/src/main/resources/META-INF/services/org.junit.platform.launcher.PostDiscoveryFilter
@@ -1,0 +1,1 @@
+io.qase.junit5.Junit5PostDiscoveryFilter

--- a/qase-testng-reporter/pom.xml
+++ b/qase-testng-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.3</version>
+        <version>4.0.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
This pull request includes a version update for the `qase-java` project to 4.0.4 and introduces new functionality for the Junit5 reporter. The most important changes include the addition of support for running tests included in a test plan for Junit5, updates to the `pom.xml` files to reflect the new version, and an upgrade of the `junit-platform-engine` dependency.

New functionality:

* Implemented support for running only the tests included in a test plan for the Junit5 reporter. This feature can be enabled by specifying the test plan ID in the reporter configuration, either in the `qase.config.json` file or through the `QASE_TESTOPS_PLAN_ID` environment variable. (`changelog.md`: [[1]](diffhunk://#diff-3bd14d078188074c410028847113ceae68865d0ad5b844a27183ef87fbe2fcc3R1-R13) `qase-junit5-reporter/src/main/java/io/qase/junit5/Junit5PostDiscoveryFilter.java`: [[2]](diffhunk://#diff-da7ddee36eb0eeb4ab540b6be437c0181c590dad43d88ee7d7506361330a3a78R1-R50) `qase-junit5-reporter/src/main/resources/META-INF/services/org.junit.platform.launcher.PostDiscoveryFilter`: [[3]](diffhunk://#diff-1111b8573c4e3f6948f3c0ef62de69d9166c6600ef8a476aa05310e80d756b07R1)

Version updates:

* Updated the project version to 4.0.4 in the main `pom.xml` file and all module-specific `pom.xml` files. (`pom.xml`: [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L10-R10) `qase-api-client/pom.xml`: [[2]](diffhunk://#diff-514718fdfdacca86f2493ed9c6b28cc51a1345d76c874502fac7f18fb2281ac3L8-R8) `qase-api-v2-client/pom.xml`: [[3]](diffhunk://#diff-b2f841fbc79604c93661caea3c4160164f6067df2d25120c4525a3cadb4298d4L9-R9) `qase-cucumber-v3-reporter/pom.xml`: [[4]](diffhunk://#diff-52c515b32b1f02b9f152f58e3e0e18a219cb44a72102b327c800d746db5fc8dcL8-R8) `qase-cucumber-v4-reporter/pom.xml`: [[5]](diffhunk://#diff-86b8d7f9216c05d31872fdbe761c485f366052ebe73550b87426703a2aa75641L8-R8) `qase-cucumber-v5-reporter/pom.xml`: [[6]](diffhunk://#diff-2a13ac9cd6493cd0ee2b5f04cbdf7468938e3b1e7265bac614812a75ba4ee713L8-R8) `qase-cucumber-v6-reporter/pom.xml`: [[7]](diffhunk://#diff-8dca3b4b2c0f85527d8bbf623069a53ae88d17ff67f00c67b71a1806199886adL8-R8) `qase-cucumber-v7-reporter/pom.xml`: [[8]](diffhunk://#diff-b14d9176febd68d8f2592505f4cad251e87e159ae3b1d07778ffea38abcc0ec9L8-R8) `qase-java-commons/pom.xml`: [[9]](diffhunk://#diff-fd60886a06671d6036def9287c94fe81b41d8febdd96e19da87d65aefbf36bdaL9-R9) `qase-junit4-reporter/pom.xml`: [[10]](diffhunk://#diff-79a1b271637ed57e83005174230b63752c7e9165c49d2d19daae2a57c8d85bc7L8-R8) `qase-junit5-reporter/pom.xml`: [[11]](diffhunk://#diff-c37a1a3bee150a3b54679b00ff4e69fbfa400fba50dc3d14a9c7a15571ca0039L8-R8) `qase-testng-reporter/pom.xml`: [[12]](diffhunk://#diff-2d7da0f3d513459b39793e52a7e3ffb2d05af6c1f851b303fe68ef7815db7814L8-R8)

Dependency update:

* Upgraded `junit-platform-engine` dependency from version 1.6.2 to 1.9.0. (`pom.xml`: [pom.xmlL38-R38](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L38-R38))