### PR TITLE
fix: resolve PatternSyntaxException in Cucumber reporters

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+# qase-java 4.0.7
+
+## What's new
+
+Resolved PatternSyntaxException in Cucumber reporters caused by unescaped trailing backslash in regular expressions.
+
 # qase-java 4.0.6
 
 ## What's new

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.qase</groupId>
     <artifactId>qase-java</artifactId>
     <packaging>pom</packaging>
-    <version>4.0.6</version>
+    <version>4.0.7</version>
     <modules>
         <module>qase-java-commons</module>
         <module>qase-api-client</module>

--- a/qase-api-client/pom.xml
+++ b/qase-api-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.6</version>
+        <version>4.0.7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-api-v2-client/pom.xml
+++ b/qase-api-v2-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.qase</groupId>
         <artifactId>qase-java</artifactId>
-        <version>4.0.6</version>
+        <version>4.0.7</version>
     </parent>
 
     <artifactId>qase-api-v2-client</artifactId>

--- a/qase-cucumber-v3-reporter/pom.xml
+++ b/qase-cucumber-v3-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.6</version>
+        <version>4.0.7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v4-reporter/pom.xml
+++ b/qase-cucumber-v4-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.6</version>
+        <version>4.0.7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v5-reporter/pom.xml
+++ b/qase-cucumber-v5-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.6</version>
+        <version>4.0.7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v5-reporter/src/main/java/io/qase/cucumber5/QaseEventListener.java
+++ b/qase-cucumber-v5-reporter/src/main/java/io/qase/cucumber5/QaseEventListener.java
@@ -8,7 +8,6 @@ import io.qase.commons.models.domain.*;
 import io.qase.commons.reporters.CoreReporterFactory;
 import io.cucumber.plugin.ConcurrentEventListener;
 import io.qase.commons.reporters.Reporter;
-import okio.Path;
 
 import java.util.List;
 import java.util.Map;
@@ -102,7 +101,7 @@ public class QaseEventListener implements ConcurrentEventListener {
             }
         } else {
             SuiteData className = new SuiteData();
-            String[] parts = event.getTestCase().getScenarioDesignation().split(":")[0].split(Path.DIRECTORY_SEPARATOR);
+            String[] parts = event.getTestCase().getUri().toString().split("/");
             className.title = parts[parts.length - 1];
             relations.suite.data.add(className);
         }

--- a/qase-cucumber-v6-reporter/pom.xml
+++ b/qase-cucumber-v6-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.6</version>
+        <version>4.0.7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v6-reporter/src/main/java/io/qase/cucumber6/QaseEventListener.java
+++ b/qase-cucumber-v6-reporter/src/main/java/io/qase/cucumber6/QaseEventListener.java
@@ -8,7 +8,6 @@ import io.qase.commons.models.domain.*;
 import io.qase.commons.reporters.CoreReporterFactory;
 import io.cucumber.plugin.ConcurrentEventListener;
 import io.qase.commons.reporters.Reporter;
-import okio.Path;
 
 import java.util.List;
 import java.util.Map;
@@ -102,7 +101,7 @@ public class QaseEventListener implements ConcurrentEventListener {
             }
         } else {
             SuiteData className = new SuiteData();
-            String[] parts = event.getTestCase().getScenarioDesignation().split(":")[0].split(Path.DIRECTORY_SEPARATOR);
+            String[] parts = event.getTestCase().getUri().toString().split("/");
             className.title = parts[parts.length - 1];
             relations.suite.data.add(className);
         }

--- a/qase-cucumber-v7-reporter/pom.xml
+++ b/qase-cucumber-v7-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.6</version>
+        <version>4.0.7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v7-reporter/src/main/java/io/qase/cucumber7/QaseEventListener.java
+++ b/qase-cucumber-v7-reporter/src/main/java/io/qase/cucumber7/QaseEventListener.java
@@ -8,7 +8,6 @@ import io.qase.commons.models.domain.*;
 import io.qase.commons.reporters.CoreReporterFactory;
 import io.cucumber.plugin.ConcurrentEventListener;
 import io.qase.commons.reporters.Reporter;
-import okio.Path;
 
 import java.util.List;
 import java.util.Map;
@@ -102,7 +101,7 @@ public class QaseEventListener implements ConcurrentEventListener {
             }
         } else {
             SuiteData className = new SuiteData();
-            String[] parts = event.getTestCase().getScenarioDesignation().split(":")[0].split(Path.DIRECTORY_SEPARATOR);
+            String[] parts = event.getTestCase().getUri().toString().split("/");
             className.title = parts[parts.length - 1];
             relations.suite.data.add(className);
         }

--- a/qase-java-commons/pom.xml
+++ b/qase-java-commons/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.qase</groupId>
         <artifactId>qase-java</artifactId>
-        <version>4.0.6</version>
+        <version>4.0.7</version>
     </parent>
 
     <artifactId>qase-java-commons</artifactId>

--- a/qase-junit4-reporter/pom.xml
+++ b/qase-junit4-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.6</version>
+        <version>4.0.7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-junit5-reporter/pom.xml
+++ b/qase-junit5-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.6</version>
+        <version>4.0.7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-testng-reporter/pom.xml
+++ b/qase-testng-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.6</version>
+        <version>4.0.7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
This pull request includes updates to the `qase-java` library, specifically version updates and bug fixes. The most important changes include resolving a `PatternSyntaxException` in Cucumber reporters and updating the version numbers across multiple `pom.xml` files to `4.0.7`.

### Version Updates:
* Updated version from `4.0.6` to `4.0.7` in `pom.xml` files for the following modules:
  - `qase-java`
  - `qase-api-client`
  - `qase-api-v2-client`
  - `qase-cucumber-v3-reporter`
  - `qase-cucumber-v4-reporter`
  - `qase-cucumber-v5-reporter`
  - `qase-cucumber-v6-reporter`
  - `qase-cucumber-v7-reporter`
  - `qase-java-commons`
  - `qase-junit4-reporter`
  - `qase-junit5-reporter`
  - `qase-testng-reporter`

### Bug Fixes:
* Resolved `PatternSyntaxException` in Cucumber reporters caused by unescaped trailing backslash in regular expressions (`changelog.md`)
* Fixed path splitting issue in `QaseEventListener` for Cucumber v5, v6, and v7 reporters by changing from `Path.DIRECTORY_SEPARATOR` to `"/"`:
  - `qase-cucumber-v5-reporter/src/main/java/io/qase/cucumber5/QaseEventListener.java`
  - `qase-cucumber-v6-reporter/src/main/java/io/qase/cucumber6/QaseEventListener.java`
  - `qase-cucumber-v7-reporter/src/main/java/io/qase/cucumber7/QaseEventListener.java`
* Removed unused import `okio.Path` from `QaseEventListener` classes for Cucumber v5, v6, and v7 reporters:
  - `qase-cucumber-v5-reporter/src/main/java/io/qase/cucumber5/QaseEventListener.java`
  - `qase-cucumber-v6-reporter/src/main/java/io/qase/cucumber6/QaseEventListener.java`
  - `qase-cucumber-v7-reporter/src/main/java/io/qase/cucumber7/QaseEventListener.java`