### PR TITLE
feat: add attach method with byte array support in Cucumber reporters

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+# qase-java 4.0.8
+
+## What's new
+
+Added a new `attach` method in Cucumber reporters that allows passing a byte array to attach files to test results.
+
 # qase-java 4.0.7
 
 ## What's new

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.qase</groupId>
     <artifactId>qase-java</artifactId>
     <packaging>pom</packaging>
-    <version>4.0.7</version>
+    <version>4.0.8</version>
     <modules>
         <module>qase-java-commons</module>
         <module>qase-api-client</module>

--- a/qase-api-client/pom.xml
+++ b/qase-api-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.7</version>
+        <version>4.0.8</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-api-v2-client/pom.xml
+++ b/qase-api-v2-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.qase</groupId>
         <artifactId>qase-java</artifactId>
-        <version>4.0.7</version>
+        <version>4.0.8</version>
     </parent>
 
     <artifactId>qase-api-v2-client</artifactId>

--- a/qase-cucumber-v3-reporter/pom.xml
+++ b/qase-cucumber-v3-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.7</version>
+        <version>4.0.8</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v3-reporter/src/main/java/io/qase/cucumber3/Qase.java
+++ b/qase-cucumber-v3-reporter/src/main/java/io/qase/cucumber3/Qase.java
@@ -14,4 +14,8 @@ public class Qase {
     public static void attach(String fileName, String content, String contentType) {
         Methods.addAttachment(fileName, content, contentType);
     }
+
+    public static void attach(String fileName, byte[] content, String contentType) {
+        Methods.addAttachment(fileName, content, contentType);
+    }
 }

--- a/qase-cucumber-v4-reporter/pom.xml
+++ b/qase-cucumber-v4-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.7</version>
+        <version>4.0.8</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v4-reporter/src/main/java/io/qase/cucumber4/Qase.java
+++ b/qase-cucumber-v4-reporter/src/main/java/io/qase/cucumber4/Qase.java
@@ -14,4 +14,8 @@ public class Qase {
     public static void attach(String fileName, String content, String contentType) {
         Methods.addAttachment(fileName, content, contentType);
     }
+
+    public static void attach(String fileName, byte[] content, String contentType) {
+        Methods.addAttachment(fileName, content, contentType);
+    }
 }

--- a/qase-cucumber-v5-reporter/pom.xml
+++ b/qase-cucumber-v5-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.7</version>
+        <version>4.0.8</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v5-reporter/src/main/java/io/qase/cucumber5/Qase.java
+++ b/qase-cucumber-v5-reporter/src/main/java/io/qase/cucumber5/Qase.java
@@ -14,4 +14,8 @@ public class Qase {
     public static void attach(String fileName, String content, String contentType) {
         Methods.addAttachment(fileName, content, contentType);
     }
+
+    public static void attach(String fileName, byte[] content, String contentType) {
+        Methods.addAttachment(fileName, content, contentType);
+    }
 }

--- a/qase-cucumber-v6-reporter/pom.xml
+++ b/qase-cucumber-v6-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.7</version>
+        <version>4.0.8</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v6-reporter/src/main/java/io/qase/cucumber6/Qase.java
+++ b/qase-cucumber-v6-reporter/src/main/java/io/qase/cucumber6/Qase.java
@@ -14,4 +14,8 @@ public class Qase {
     public static void attach(String fileName, String content, String contentType) {
         Methods.addAttachment(fileName, content, contentType);
     }
+
+    public static void attach(String fileName, byte[] content, String contentType) {
+        Methods.addAttachment(fileName, content, contentType);
+    }
 }

--- a/qase-cucumber-v7-reporter/pom.xml
+++ b/qase-cucumber-v7-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.7</version>
+        <version>4.0.8</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v7-reporter/src/main/java/io/qase/cucumber7/Qase.java
+++ b/qase-cucumber-v7-reporter/src/main/java/io/qase/cucumber7/Qase.java
@@ -14,4 +14,8 @@ public class Qase {
     public static void attach(String fileName, String content, String contentType) {
         Methods.addAttachment(fileName, content, contentType);
     }
+
+    public static void attach(String fileName, byte[] content, String contentType) {
+        Methods.addAttachment(fileName, content, contentType);
+    }
 }

--- a/qase-java-commons/pom.xml
+++ b/qase-java-commons/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.qase</groupId>
         <artifactId>qase-java</artifactId>
-        <version>4.0.7</version>
+        <version>4.0.8</version>
     </parent>
 
     <artifactId>qase-java-commons</artifactId>

--- a/qase-java-commons/src/main/java/io/qase/commons/Methods.java
+++ b/qase-java-commons/src/main/java/io/qase/commons/Methods.java
@@ -43,4 +43,17 @@ public class Methods {
             CasesStorage.getCurrentCase().attachments.add(attachment);
         }
     }
+
+    public static void addAttachment(String fileName, byte[] content, String contentType) {
+        Attachment attachment = new Attachment();
+        attachment.fileName = fileName;
+        attachment.contentBytes = content;
+        attachment.mimeType = contentType;
+
+        if (StepStorage.isStepInProgress()) {
+            StepStorage.getCurrentStep().attachments.add(attachment);
+        } else {
+            CasesStorage.getCurrentCase().attachments.add(attachment);
+        }
+    }
 }

--- a/qase-java-commons/src/main/java/io/qase/commons/client/ApiClientV1.java
+++ b/qase-java-commons/src/main/java/io/qase/commons/client/ApiClientV1.java
@@ -16,6 +16,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Paths;
@@ -219,12 +220,23 @@ public class ApiClientV1 implements io.qase.commons.client.ApiClient {
 
         if (attachment.filePath != null) {
             file = new File(attachment.filePath);
-        } else {
+        } else if (attachment.content != null) {
             String tempPath = Paths.get(System.getProperty("user.dir"), attachment.fileName).toString();
             file = new File(tempPath);
 
             try (FileWriter fileWriter = new FileWriter(file)) {
                 fileWriter.write(attachment.content);
+                removeFile = true;
+            } catch (IOException e) {
+                logger.error("Failed to write attachment content to file: {}", e.getMessage());
+                return "";
+            }
+        } else {
+            String tempPath = Paths.get(System.getProperty("user.dir"), attachment.fileName).toString();
+            file = new File(tempPath);
+
+            try (FileOutputStream fos = new FileOutputStream(file)) {
+                fos.write(attachment.contentBytes);
                 removeFile = true;
             } catch (IOException e) {
                 logger.error("Failed to write attachment content to file: {}", e.getMessage());

--- a/qase-java-commons/src/main/java/io/qase/commons/models/domain/Attachment.java
+++ b/qase-java-commons/src/main/java/io/qase/commons/models/domain/Attachment.java
@@ -7,5 +7,6 @@ public class Attachment {
     public String fileName;
     public String mimeType;
     public String content;
+    public byte[] contentBytes;
     public String filePath;
 }

--- a/qase-junit4-reporter/pom.xml
+++ b/qase-junit4-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.7</version>
+        <version>4.0.8</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-junit5-reporter/pom.xml
+++ b/qase-junit5-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.7</version>
+        <version>4.0.8</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-testng-reporter/pom.xml
+++ b/qase-testng-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.7</version>
+        <version>4.0.8</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
This pull request includes updates to the `qase-java` library, specifically adding a new method for attaching files as byte arrays in Cucumber reporters and updating the version to 4.0.8 across various modules.

### New Feature:
* Added a new `attach` method in Cucumber reporters that allows passing a byte array to attach files to test results. (`qase-cucumber-v3-reporter/src/main/java/io/qase/cucumber3/Qase.java`, `qase-cucumber-v4-reporter/src/main/java/io/qase/cucumber4/Qase.java`, `qase-cucumber-v5-reporter/src/main/java/io/qase/cucumber5/Qase.java`, `qase-cucumber-v6-reporter/src/main/java/io/qase/cucumber6/Qase.java`, `qase-cucumber-v7-reporter/src/main/java/io/qase/cucumber7/Qase.java`) [[1]](diffhunk://#diff-55ac97d2306a556eb4df3e8874b3412eff762924e2c4099796c0170b88194b4eR17-R20) [[2]](diffhunk://#diff-e2a8380d29da2aa5bd26f6512a2f3903ccde4b175c94c6987822b2e606994f58R17-R20) [[3]](diffhunk://#diff-a6eba0d4426b705c66d481773c650225acba77488dc2e2a4324448fd15eac28fR17-R20) [[4]](diffhunk://#diff-8b274848d7ab06deccaa49d7fcc25853672ea40ed1558a6b85d7654ba5f0c85fR17-R20) [[5]](diffhunk://#diff-cba0d0a9c3e505b89cb469e3f66b55e9d0e28506d7105a0340f09b0aa5ff1781R17-R20)

### Version Updates:
* Updated the version to 4.0.8 in `pom.xml` files across multiple modules. (`pom.xml`, `qase-api-client/pom.xml`, `qase-api-v2-client/pom.xml`, `qase-cucumber-v3-reporter/pom.xml`, `qase-cucumber-v4-reporter/pom.xml`, `qase-cucumber-v5-reporter/pom.xml`, `qase-cucumber-v6-reporter/pom.xml`, `qase-cucumber-v7-reporter/pom.xml`, `qase-java-commons/pom.xml`, `qase-junit4-reporter/pom.xml`, `qase-junit5-reporter/pom.xml`) [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L10-R10) [[2]](diffhunk://#diff-514718fdfdacca86f2493ed9c6b28cc51a1345d76c874502fac7f18fb2281ac3L8-R8) [[3]](diffhunk://#diff-b2f841fbc79604c93661caea3c4160164f6067df2d25120c4525a3cadb4298d4L9-R9) [[4]](diffhunk://#diff-52c515b32b1f02b9f152f58e3e0e18a219cb44a72102b327c800d746db5fc8dcL8-R8) [[5]](diffhunk://#diff-86b8d7f9216c05d31872fdbe761c485f366052ebe73550b87426703a2aa75641L8-R8) [[6]](diffhunk://#diff-2a13ac9cd6493cd0ee2b5f04cbdf7468938e3b1e7265bac614812a75ba4ee713L8-R8) [[7]](diffhunk://#diff-8dca3b4b2c0f85527d8bbf623069a53ae88d17ff67f00c67b71a1806199886adL8-R8) [[8]](diffhunk://#diff-b14d9176febd68d8f2592505f4cad251e87e159ae3b1d07778ffea38abcc0ec9L8-R8) [[9]](diffhunk://#diff-fd60886a06671d6036def9287c94fe81b41d8febdd96e19da87d65aefbf36bdaL9-R9) [[10]](diffhunk://#diff-79a1b271637ed57e83005174230b63752c7e9165c49d2d19daae2a57c8d85bc7L8-R8) [[11]](diffhunk://#diff-c37a1a3bee150a3b54679b00ff4e69fbfa400fba50dc3d14a9c7a15571ca0039L8-R8)

### Code Enhancements:
* Enhanced the `Methods` class to support adding attachments as byte arrays. (`qase-java-commons/src/main/java/io/qase/commons/Methods.java`)
* Updated the `ApiClientV1` class to handle attachments with byte arrays. (`qase-java-commons/src/main/java/io/qase/commons/client/ApiClientV1.java`) [[1]](diffhunk://#diff-e8f0c158c138dae8c37de4b8c5c26f69c10eb5adac3d26454c5606a0ffcc5a10R19) [[2]](diffhunk://#diff-e8f0c158c138dae8c37de4b8c5c26f69c10eb5adac3d26454c5606a0ffcc5a10L222-R223) [[3]](diffhunk://#diff-e8f0c158c138dae8c37de4b8c5c26f69c10eb5adac3d26454c5606a0ffcc5a10R234-R244)
* Added a `contentBytes` field to the `Attachment` class to store byte array content. (`qase-java-commons/src/main/java/io/qase/commons/models/domain/Attachment.java`)

### Documentation:
* Updated the `changelog.md` to reflect the new version 4.0.8 and the addition of the new `attach` method. (`changelog.md`)