### PR TITLE
fix: ensure execution.start_time is in UTC to prevent submission errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea
 *.iml
 target/
+
+.DS_Store

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,10 @@
+# qase-java 4.0.9
+
+## What's new
+
+Resolved an issue where `execution.start_time` was not in UTC, leading to submission errors (
+`The execution.start time must be at least {unix time}`).
+
 # qase-java 4.0.8
 
 ## What's new

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.qase</groupId>
     <artifactId>qase-java</artifactId>
     <packaging>pom</packaging>
-    <version>4.0.8</version>
+    <version>4.0.9</version>
     <modules>
         <module>qase-java-commons</module>
         <module>qase-api-client</module>

--- a/qase-api-client/pom.xml
+++ b/qase-api-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.8</version>
+        <version>4.0.9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-api-v2-client/pom.xml
+++ b/qase-api-v2-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.qase</groupId>
         <artifactId>qase-java</artifactId>
-        <version>4.0.8</version>
+        <version>4.0.9</version>
     </parent>
 
     <artifactId>qase-api-v2-client</artifactId>

--- a/qase-cucumber-v3-reporter/pom.xml
+++ b/qase-cucumber-v3-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.8</version>
+        <version>4.0.9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v3-reporter/src/main/java/io/qase/cucumber3/QaseEventListener.java
+++ b/qase-cucumber-v3-reporter/src/main/java/io/qase/cucumber3/QaseEventListener.java
@@ -13,6 +13,7 @@ import io.qase.commons.reporters.CoreReporterFactory;
 import io.qase.commons.reporters.Reporter;
 import okio.Path;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -118,7 +119,8 @@ public class QaseEventListener implements Formatter {
 
         resultCreate.title = caseTitle;
         resultCreate.testopsId = caseId;
-        resultCreate.execution.startTime = System.currentTimeMillis();
+        resultCreate.execution.startTime = Instant.now().toEpochMilli();
+        resultCreate.execution.thread = Thread.currentThread().getName();
         resultCreate.fields = fields;
         resultCreate.relations = relations;
 
@@ -137,10 +139,10 @@ public class QaseEventListener implements Formatter {
                 .flatMap(throwable -> Optional.of(getStacktrace(throwable))).orElse(null);
 
         resultCreate.execution.status = convertStatus(event.result.getStatus());
-        resultCreate.execution.endTime = System.currentTimeMillis();
+        resultCreate.execution.endTime = Instant.now().toEpochMilli();
         resultCreate.execution.duration = (int) (resultCreate.execution.endTime - resultCreate.execution.startTime);
         resultCreate.execution.stacktrace = stacktrace;
-        resultCreate.steps = StepStorage.stopSteps();;
+        resultCreate.steps = StepStorage.stopSteps();
 
         optionalThrowable.ifPresent(throwable ->
                 resultCreate.message = Optional.ofNullable(resultCreate.message)

--- a/qase-cucumber-v4-reporter/pom.xml
+++ b/qase-cucumber-v4-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.8</version>
+        <version>4.0.9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v4-reporter/src/main/java/io/qase/cucumber4/QaseEventListener.java
+++ b/qase-cucumber-v4-reporter/src/main/java/io/qase/cucumber4/QaseEventListener.java
@@ -12,6 +12,7 @@ import io.qase.commons.reporters.CoreReporterFactory;
 import io.qase.commons.reporters.Reporter;
 import okio.Path;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -117,7 +118,8 @@ public class QaseEventListener implements ConcurrentEventListener {
 
         resultCreate.title = caseTitle;
         resultCreate.testopsId = caseId;
-        resultCreate.execution.startTime = System.currentTimeMillis();
+        resultCreate.execution.startTime = Instant.now().toEpochMilli();
+        resultCreate.execution.thread = Thread.currentThread().getName();
         resultCreate.fields = fields;
         resultCreate.relations = relations;
 
@@ -136,10 +138,10 @@ public class QaseEventListener implements ConcurrentEventListener {
                 .flatMap(throwable -> Optional.of(getStacktrace(throwable))).orElse(null);
 
         resultCreate.execution.status = convertStatus(event.result.getStatus());
-        resultCreate.execution.endTime = System.currentTimeMillis();
+        resultCreate.execution.endTime = Instant.now().toEpochMilli();
         resultCreate.execution.duration = (int) (resultCreate.execution.endTime - resultCreate.execution.startTime);
         resultCreate.execution.stacktrace = stacktrace;
-        resultCreate.steps = StepStorage.stopSteps();;
+        resultCreate.steps = StepStorage.stopSteps();
 
         optionalThrowable.ifPresent(throwable ->
                 resultCreate.message = Optional.ofNullable(resultCreate.message)

--- a/qase-cucumber-v5-reporter/pom.xml
+++ b/qase-cucumber-v5-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.8</version>
+        <version>4.0.9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v5-reporter/src/main/java/io/qase/cucumber5/QaseEventListener.java
+++ b/qase-cucumber-v5-reporter/src/main/java/io/qase/cucumber5/QaseEventListener.java
@@ -9,6 +9,7 @@ import io.qase.commons.reporters.CoreReporterFactory;
 import io.cucumber.plugin.ConcurrentEventListener;
 import io.qase.commons.reporters.Reporter;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -53,7 +54,7 @@ public class QaseEventListener implements ConcurrentEventListener {
         if (testStepFinished.getTestStep() instanceof PickleStepTestStep) {
             PickleStepTestStep step = (PickleStepTestStep) testStepFinished.getTestStep();
             StepResult stepResult = StepStorage.getCurrentStep();
-            stepResult.data.action = step.getStepText();
+            stepResult.data.action = step.getStep().getText();
             stepResult.execution.status = this.convertStepStatus(testStepFinished.getResult().getStatus());
             StepStorage.stopStep();
         }
@@ -108,7 +109,8 @@ public class QaseEventListener implements ConcurrentEventListener {
 
         resultCreate.title = caseTitle;
         resultCreate.testopsId = caseId;
-        resultCreate.execution.startTime = System.currentTimeMillis();
+        resultCreate.execution.startTime = Instant.now().toEpochMilli();
+        resultCreate.execution.thread = Thread.currentThread().getName();
         resultCreate.fields = fields;
         resultCreate.relations = relations;
 
@@ -127,7 +129,7 @@ public class QaseEventListener implements ConcurrentEventListener {
                 .flatMap(throwable -> Optional.of(getStacktrace(throwable))).orElse(null);
 
         resultCreate.execution.status = convertStatus(event.getResult().getStatus());
-        resultCreate.execution.endTime = System.currentTimeMillis();
+        resultCreate.execution.endTime = Instant.now().toEpochMilli();
         resultCreate.execution.duration = (int) (resultCreate.execution.endTime - resultCreate.execution.startTime);
         resultCreate.execution.stacktrace = stacktrace;
         resultCreate.steps = StepStorage.stopSteps();

--- a/qase-cucumber-v6-reporter/pom.xml
+++ b/qase-cucumber-v6-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.8</version>
+        <version>4.0.9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v6-reporter/src/main/java/io/qase/cucumber6/QaseEventListener.java
+++ b/qase-cucumber-v6-reporter/src/main/java/io/qase/cucumber6/QaseEventListener.java
@@ -9,6 +9,7 @@ import io.qase.commons.reporters.CoreReporterFactory;
 import io.cucumber.plugin.ConcurrentEventListener;
 import io.qase.commons.reporters.Reporter;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -53,7 +54,7 @@ public class QaseEventListener implements ConcurrentEventListener {
         if (testStepFinished.getTestStep() instanceof PickleStepTestStep) {
             PickleStepTestStep step = (PickleStepTestStep) testStepFinished.getTestStep();
             StepResult stepResult = StepStorage.getCurrentStep();
-            stepResult.data.action = step.getStepText();
+            stepResult.data.action = step.getStep().getText();
             stepResult.execution.status = this.convertStepStatus(testStepFinished.getResult().getStatus());
             StepStorage.stopStep();
         }
@@ -108,7 +109,8 @@ public class QaseEventListener implements ConcurrentEventListener {
 
         resultCreate.title = caseTitle;
         resultCreate.testopsId = caseId;
-        resultCreate.execution.startTime = System.currentTimeMillis();
+        resultCreate.execution.startTime = Instant.now().toEpochMilli();
+        resultCreate.execution.thread = Thread.currentThread().getName();
         resultCreate.fields = fields;
         resultCreate.relations = relations;
 
@@ -127,7 +129,7 @@ public class QaseEventListener implements ConcurrentEventListener {
                 .flatMap(throwable -> Optional.of(getStacktrace(throwable))).orElse(null);
 
         resultCreate.execution.status = convertStatus(event.getResult().getStatus());
-        resultCreate.execution.endTime = System.currentTimeMillis();
+        resultCreate.execution.endTime = Instant.now().toEpochMilli();
         resultCreate.execution.duration = (int) (resultCreate.execution.endTime - resultCreate.execution.startTime);
         resultCreate.execution.stacktrace = stacktrace;
         resultCreate.steps = StepStorage.stopSteps();

--- a/qase-cucumber-v7-reporter/pom.xml
+++ b/qase-cucumber-v7-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.8</version>
+        <version>4.0.9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v7-reporter/src/main/java/io/qase/cucumber7/QaseEventListener.java
+++ b/qase-cucumber-v7-reporter/src/main/java/io/qase/cucumber7/QaseEventListener.java
@@ -9,6 +9,7 @@ import io.qase.commons.reporters.CoreReporterFactory;
 import io.cucumber.plugin.ConcurrentEventListener;
 import io.qase.commons.reporters.Reporter;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -53,7 +54,7 @@ public class QaseEventListener implements ConcurrentEventListener {
         if (testStepFinished.getTestStep() instanceof PickleStepTestStep) {
             PickleStepTestStep step = (PickleStepTestStep) testStepFinished.getTestStep();
             StepResult stepResult = StepStorage.getCurrentStep();
-            stepResult.data.action = step.getStepText();
+            stepResult.data.action = step.getStep().getText();
             stepResult.execution.status = this.convertStepStatus(testStepFinished.getResult().getStatus());
             StepStorage.stopStep();
         }
@@ -108,7 +109,8 @@ public class QaseEventListener implements ConcurrentEventListener {
 
         resultCreate.title = caseTitle;
         resultCreate.testopsId = caseId;
-        resultCreate.execution.startTime = System.currentTimeMillis();
+        resultCreate.execution.startTime = Instant.now().toEpochMilli();
+        resultCreate.execution.thread = Thread.currentThread().getName();
         resultCreate.fields = fields;
         resultCreate.relations = relations;
 
@@ -127,7 +129,7 @@ public class QaseEventListener implements ConcurrentEventListener {
                 .flatMap(throwable -> Optional.of(getStacktrace(throwable))).orElse(null);
 
         resultCreate.execution.status = convertStatus(event.getResult().getStatus());
-        resultCreate.execution.endTime = System.currentTimeMillis();
+        resultCreate.execution.endTime = Instant.now().toEpochMilli();
         resultCreate.execution.duration = (int) (resultCreate.execution.endTime - resultCreate.execution.startTime);
         resultCreate.execution.stacktrace = stacktrace;
         resultCreate.steps = StepStorage.stopSteps();

--- a/qase-java-commons/pom.xml
+++ b/qase-java-commons/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.qase</groupId>
         <artifactId>qase-java</artifactId>
-        <version>4.0.8</version>
+        <version>4.0.9</version>
     </parent>
 
     <artifactId>qase-java-commons</artifactId>

--- a/qase-java-commons/src/main/java/io/qase/commons/client/ApiClientV2.java
+++ b/qase-java-commons/src/main/java/io/qase/commons/client/ApiClientV2.java
@@ -11,7 +11,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -168,6 +167,9 @@ public class ApiClientV2 implements ApiClient {
 
         ResultStepExecution execution = new ResultStepExecution()
                 .status(ResultStepStatus.fromValue(step.execution.status.toString().toLowerCase()))
+                .startTime(step.execution.startTime / 1000.0)
+                .endTime(step.execution.endTime / 1000.0)
+                .duration(step.execution.duration)
                 .attachments(attachments);
         List<Object> steps = step.steps.stream()
                 .map(this::convertStepResult).collect(Collectors.toList());

--- a/qase-java-commons/src/main/java/io/qase/commons/models/domain/StepExecution.java
+++ b/qase-java-commons/src/main/java/io/qase/commons/models/domain/StepExecution.java
@@ -1,19 +1,21 @@
 package io.qase.commons.models.domain;
 
+import java.time.Instant;
+
 public class StepExecution {
     public StepResultStatus status;
-    public long startTime;
-    public long endTime;
-    public int duration;
+    public Long startTime;
+    public Long endTime;
+    public Long duration;
 
     public StepExecution() {
-        this.startTime = System.currentTimeMillis();
+        this.startTime = Instant.now().toEpochMilli();
         this.status = StepResultStatus.UNTESTED;
     }
 
     public void stop() {
-        this.endTime = System.currentTimeMillis();
-        this.duration = (int) (this.endTime - this.startTime);
+        this.endTime = Instant.now().toEpochMilli();
+        this.duration = this.endTime - this.startTime;
     }
 }
 

--- a/qase-java-commons/src/main/java/io/qase/commons/reporters/FileReporter.java
+++ b/qase-java-commons/src/main/java/io/qase/commons/reporters/FileReporter.java
@@ -12,6 +12,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.gson.Gson;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -34,13 +35,13 @@ public class FileReporter implements InternalReporter {
 
     @Override
     public void startTestRun() throws QaseException {
-        this.startTime = System.currentTimeMillis();
+        this.startTime = Instant.now().toEpochMilli();
         this.writer.prepare();
     }
 
     @Override
     public void completeTestRun() throws QaseException {
-        long endTime = System.currentTimeMillis();
+        long endTime = Instant.now().toEpochMilli();
 
         Gson gson = new Gson();
 

--- a/qase-junit4-reporter/pom.xml
+++ b/qase-junit4-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.8</version>
+        <version>4.0.9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-junit4-reporter/src/main/java/io/qase/junit4/QaseListener.java
+++ b/qase-junit4-reporter/src/main/java/io/qase/junit4/QaseListener.java
@@ -13,6 +13,7 @@ import org.junit.runner.Description;
 import org.junit.runner.notification.Failure;
 import org.junit.runner.notification.RunListener;
 
+import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -134,7 +135,8 @@ public class QaseListener extends RunListener {
             relations.suite.data.add(className);
         }
 
-        resultCreate.execution.startTime = System.currentTimeMillis();
+        resultCreate.execution.startTime = Instant.now().toEpochMilli();
+        resultCreate.execution.thread = Thread.currentThread().getName();
         resultCreate.testopsId = caseId;
         resultCreate.title = caseTitle;
         resultCreate.fields = fields;
@@ -157,7 +159,7 @@ public class QaseListener extends RunListener {
         LinkedList<StepResult> steps = StepStorage.stopSteps();
 
         resultCreate.execution.status = status;
-        resultCreate.execution.endTime = System.currentTimeMillis();
+        resultCreate.execution.endTime = Instant.now().toEpochMilli();
         resultCreate.execution.duration = (int) (resultCreate.execution.endTime - resultCreate.execution.startTime);
         resultCreate.execution.stacktrace = stacktrace;
         resultCreate.steps = steps;

--- a/qase-junit5-reporter/pom.xml
+++ b/qase-junit5-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.8</version>
+        <version>4.0.9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-junit5-reporter/src/main/java/io/qase/junit5/QaseListener.java
+++ b/qase-junit5-reporter/src/main/java/io/qase/junit5/QaseListener.java
@@ -11,6 +11,7 @@ import org.junit.platform.launcher.TestPlan;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
+import java.time.Instant;
 import java.util.*;
 
 import static io.qase.commons.utils.IntegrationUtils.*;
@@ -96,7 +97,8 @@ public class QaseListener implements TestExecutionListener, Extension, BeforeAll
             relations.suite.data.add(className);
         }
 
-        resultCreate.execution.startTime = System.currentTimeMillis();
+        resultCreate.execution.startTime = Instant.now().toEpochMilli();
+        resultCreate.execution.thread = Thread.currentThread().getName();
         resultCreate.testopsId = caseId;
         resultCreate.title = caseTitle;
         resultCreate.params = parameters;
@@ -174,7 +176,7 @@ public class QaseListener implements TestExecutionListener, Extension, BeforeAll
         LinkedList<StepResult> steps = StepStorage.stopSteps();
 
         resultCreate.execution.status = status;
-        resultCreate.execution.endTime = System.currentTimeMillis();
+        resultCreate.execution.endTime = Instant.now().toEpochMilli();
         resultCreate.execution.duration = (int) (resultCreate.execution.endTime - resultCreate.execution.startTime);
         resultCreate.execution.stacktrace = stacktrace;
         resultCreate.steps = steps;

--- a/qase-testng-reporter/pom.xml
+++ b/qase-testng-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.8</version>
+        <version>4.0.9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-testng-reporter/src/main/java/io/qase/testng/QaseListener.java
+++ b/qase-testng-reporter/src/main/java/io/qase/testng/QaseListener.java
@@ -139,6 +139,7 @@ public class QaseListener implements ISuiteListener,
         }
 
         resultCreate.execution.startTime = result.getStartMillis();
+        resultCreate.execution.thread = Thread.currentThread().getName();
         resultCreate.testopsId = caseId;
         resultCreate.title = caseTitle;
         resultCreate.params = parameters;


### PR DESCRIPTION
This pull request includes updates to the `qase-java` library, specifically upgrading the version to 4.0.9 and making several improvements and fixes related to time handling and reporting. The most important changes include updating version references in various `pom.xml` files, ensuring execution times are recorded in UTC using `Instant`, and adding thread information to test results.

### Version Updates:
* Updated the version from 4.0.8 to 4.0.9 in `pom.xml` files across multiple modules, including `qase-java`, `qase-api-client`, `qase-api-v2-client`, `qase-cucumber-v3-reporter`, `qase-cucumber-v4-reporter`, `qase-cucumber-v5-reporter`, `qase-cucumber-v6-reporter`, `qase-cucumber-v7-reporter`, and `qase-java-commons`. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L10-R10) [[2]](diffhunk://#diff-514718fdfdacca86f2493ed9c6b28cc51a1345d76c874502fac7f18fb2281ac3L8-R8) [[3]](diffhunk://#diff-b2f841fbc79604c93661caea3c4160164f6067df2d25120c4525a3cadb4298d4L9-R9) [[4]](diffhunk://#diff-52c515b32b1f02b9f152f58e3e0e18a219cb44a72102b327c800d746db5fc8dcL8-R8) [[5]](diffhunk://#diff-86b8d7f9216c05d31872fdbe761c485f366052ebe73550b87426703a2aa75641L8-R8) [[6]](diffhunk://#diff-2a13ac9cd6493cd0ee2b5f04cbdf7468938e3b1e7265bac614812a75ba4ee713L8-R8) [[7]](diffhunk://#diff-8dca3b4b2c0f85527d8bbf623069a53ae88d17ff67f00c67b71a1806199886adL8-R8) [[8]](diffhunk://#diff-b14d9176febd68d8f2592505f4cad251e87e159ae3b1d07778ffea38abcc0ec9L8-R8) [[9]](diffhunk://#diff-fd60886a06671d6036def9287c94fe81b41d8febdd96e19da87d65aefbf36bdaL9-R9)

### Time Handling Improvements:
* Changed the time recording mechanism from `System.currentTimeMillis()` to `Instant.now().toEpochMilli()` to ensure times are in UTC. This change affects the start and end times of test executions and step executions in multiple files, including `QaseEventListener.java` for various Cucumber versions and `StepExecution.java`. [[1]](diffhunk://#diff-b35de0b4d32354ced403864d38dc90f14618da6b97b0d4bbb0271a9df4c51371L121-R123) [[2]](diffhunk://#diff-b35de0b4d32354ced403864d38dc90f14618da6b97b0d4bbb0271a9df4c51371L140-R145) [[3]](diffhunk://#diff-a20116218ca55e1693b46b0ffd95a398d70b87ffcf0beea8472f5cace7d0c18eL120-R122) [[4]](diffhunk://#diff-a20116218ca55e1693b46b0ffd95a398d70b87ffcf0beea8472f5cace7d0c18eL139-R144) [[5]](diffhunk://#diff-77be9305e192abac93ea7d9d46ffd0a022e0e024d8acec88c5d3e8462a745d35L111-R113) [[6]](diffhunk://#diff-77be9305e192abac93ea7d9d46ffd0a022e0e024d8acec88c5d3e8462a745d35L130-R132) [[7]](diffhunk://#diff-4a994f83ac775195e3c9750d52cc3b6f89582537ce359b2da65247c8baea73a3L111-R113) [[8]](diffhunk://#diff-4a994f83ac775195e3c9750d52cc3b6f89582537ce359b2da65247c8baea73a3L130-R132) [[9]](diffhunk://#diff-00e1926b51da7fdba7868c958b8b087281da8c9349792ebe970159c322451e7cL111-R113) [[10]](diffhunk://#diff-00e1926b51da7fdba7868c958b8b087281da8c9349792ebe970159c322451e7cL130-R132) [[11]](diffhunk://#diff-7f2732c5988bb8ac1cd9068e5f65e958eda4823e1c0a17f0156e6838a064f4c2R3-R18)

### Reporting Enhancements:
* Added the current thread name to the test result execution details to provide more context in the reports. This change was applied in the `startTestCase` method of `QaseEventListener.java` for various Cucumber versions. [[1]](diffhunk://#diff-b35de0b4d32354ced403864d38dc90f14618da6b97b0d4bbb0271a9df4c51371L121-R123) [[2]](diffhunk://#diff-a20116218ca55e1693b46b0ffd95a398d70b87ffcf0beea8472f5cace7d0c18eL120-R122) [[3]](diffhunk://#diff-77be9305e192abac93ea7d9d46ffd0a022e0e024d8acec88c5d3e8462a745d35L111-R113) [[4]](diffhunk://#diff-4a994f83ac775195e3c9750d52cc3b6f89582537ce359b2da65247c8baea73a3L111-R113) [[5]](diffhunk://#diff-00e1926b51da7fdba7868c958b8b087281da8c9349792ebe970159c322451e7cL111-R113)

### Bug Fixes:
* Fixed an issue where `execution.start_time` was not in UTC, leading to submission errors. This fix is documented in the `changelog.md` file.
* Corrected the method used to retrieve step text in `testStepFinished` for Cucumber v5, v6, and v7 reporters. [[1]](diffhunk://#diff-77be9305e192abac93ea7d9d46ffd0a022e0e024d8acec88c5d3e8462a745d35L56-R57) [[2]](diffhunk://#diff-4a994f83ac775195e3c9750d52cc3b6f89582537ce359b2da65247c8baea73a3L56-R57) [[3]](diffhunk://#diff-00e1926b51da7fdba7868c958b8b087281da8c9349792ebe970159c322451e7cL56-R57)

### Code Cleanup:
* Removed unnecessary imports and ensured proper formatting in several Java files, including `ApiClientV2.java` and `FileReporter.java`. [[1]](diffhunk://#diff-ede9a3410dd3a0414a7405573fec97129e44a045e52f6a87e611a73049a8a2a6L14) [[2]](diffhunk://#diff-9e936505644a8faf4f58a6ed711d4d65d0c0c24b7073ae88b4e6d69614b550c3R15)