### PR TITLE
feat: add support for custom hook execution before test completion

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,10 @@
+# qase-java 4.0.10
+
+## What's new
+
+Introduced the ability to execute custom hooks before a test completes, allowing users to run custom code at the end of
+test execution. More details can be found in the [documentation](https://github.com/qase-tms/qase-java/tree/main/qase-java-commons#readme)
+
 # qase-java 4.0.9
 
 ## What's new

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.qase</groupId>
     <artifactId>qase-java</artifactId>
     <packaging>pom</packaging>
-    <version>4.0.9</version>
+    <version>4.0.10</version>
     <modules>
         <module>qase-java-commons</module>
         <module>qase-api-client</module>

--- a/qase-api-client/pom.xml
+++ b/qase-api-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.9</version>
+        <version>4.0.10</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-api-v2-client/pom.xml
+++ b/qase-api-v2-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.qase</groupId>
         <artifactId>qase-java</artifactId>
-        <version>4.0.9</version>
+        <version>4.0.10</version>
     </parent>
 
     <artifactId>qase-api-v2-client</artifactId>

--- a/qase-cucumber-v3-reporter/pom.xml
+++ b/qase-cucumber-v3-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.9</version>
+        <version>4.0.10</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v4-reporter/pom.xml
+++ b/qase-cucumber-v4-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.9</version>
+        <version>4.0.10</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v5-reporter/pom.xml
+++ b/qase-cucumber-v5-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.9</version>
+        <version>4.0.10</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v6-reporter/pom.xml
+++ b/qase-cucumber-v6-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.9</version>
+        <version>4.0.10</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v7-reporter/pom.xml
+++ b/qase-cucumber-v7-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.9</version>
+        <version>4.0.10</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-java-commons/README.md
+++ b/qase-java-commons/README.md
@@ -88,3 +88,41 @@ All configuration options are listed in the table below:
   }
 }
 ```
+
+## How to add an attachment for a failed test?
+
+You need to implement the `HooksListener` interface and override the `beforeTestStop` method.
+
+For example:
+
+```java
+import io.qase.commons.hooks.HooksListener;
+import io.qase.commons.models.domain.TestResult;
+import io.qase.commons.models.domain.TestResultStatus;
+import io.qase.testng.Qase;
+import org.openqa.selenium.OutputType;
+import org.openqa.selenium.TakesScreenshot;
+import org.openqa.selenium.WebDriver;
+
+public class AttachmentManager implements HooksListener {
+
+    @Override
+    public void beforeTestStop(final TestResult result) {
+        if (result.execution.status == TestResultStatus.FAILED) {
+            // Add a screenshot
+            Qase.attach("Failure Screenshot.png", ((TakesScreenshot) driver).getScreenshotAs(OutputType.BYTES), "image/png");
+            
+            // Add log file
+            Qase.attach("/logs/failed.log");
+            
+            // Add any text
+            Qase.attach("file.txt", "any text", "plain/text");
+        }
+    }
+}
+```
+
+After that, you need to add file **io.qase.commons.hooks.HooksListener** to **resources/META-INF/services** folder:
+```text
+<your-package>.AttachmentManager
+```

--- a/qase-java-commons/pom.xml
+++ b/qase-java-commons/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.qase</groupId>
         <artifactId>qase-java</artifactId>
-        <version>4.0.9</version>
+        <version>4.0.10</version>
     </parent>
 
     <artifactId>qase-java-commons</artifactId>

--- a/qase-java-commons/src/main/java/io/qase/commons/hooks/DefaultListener.java
+++ b/qase-java-commons/src/main/java/io/qase/commons/hooks/DefaultListener.java
@@ -1,0 +1,4 @@
+package io.qase.commons.hooks;
+
+public interface DefaultListener {
+}

--- a/qase-java-commons/src/main/java/io/qase/commons/hooks/HooksListener.java
+++ b/qase-java-commons/src/main/java/io/qase/commons/hooks/HooksListener.java
@@ -1,0 +1,9 @@
+package io.qase.commons.hooks;
+
+import io.qase.commons.models.domain.TestResult;
+
+public interface HooksListener extends DefaultListener {
+    default void beforeTestStop(final TestResult result) {
+        //do nothing
+    }
+}

--- a/qase-java-commons/src/main/java/io/qase/commons/hooks/HooksManager.java
+++ b/qase-java-commons/src/main/java/io/qase/commons/hooks/HooksManager.java
@@ -1,0 +1,38 @@
+package io.qase.commons.hooks;
+
+import io.qase.commons.models.domain.TestResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.function.BiConsumer;
+
+public class HooksManager {
+    private static final Logger logger = LoggerFactory.getLogger(HooksManager.class);
+    private final List<HooksListener> listeners;
+
+    public HooksManager(final List<HooksListener> listeners) {
+        this.listeners = listeners;
+    }
+
+    public void beforeTestStop(final TestResult result) {
+        runSafelyMethod(listeners, HooksListener::beforeTestStop, result);
+    }
+
+    protected <T extends DefaultListener, S> void runSafelyMethod(final List<T> listeners,
+                                                                  final BiConsumer<T, S> method,
+                                                                  final S object) {
+        listeners.forEach(listener -> {
+            try {
+                method.accept(listener, object);
+            } catch (Exception e) {
+                logger.error("Could not invoke listener method", e);
+            }
+        });
+    }
+
+    public static HooksManager getDefaultHooksManager() {
+        final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        return new HooksManager(HooksServiceLoader.load(HooksListener.class, classLoader));
+    }
+}

--- a/qase-java-commons/src/main/java/io/qase/commons/hooks/HooksServiceLoader.java
+++ b/qase-java-commons/src/main/java/io/qase/commons/hooks/HooksServiceLoader.java
@@ -1,0 +1,41 @@
+package io.qase.commons.hooks;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ServiceLoader;
+
+public class HooksServiceLoader {
+    private static final Logger logger = LoggerFactory.getLogger(HooksServiceLoader.class);
+
+    private HooksServiceLoader() {
+        throw new IllegalStateException("Do not have instance");
+    }
+
+    public static <T> List<T> load(final Class<T> type, final ClassLoader classLoader) {
+        final List<T> loaded = new ArrayList<>();
+        final Iterator<T> iterator = ServiceLoader.load(type, classLoader).iterator();
+        while (nextSafely(iterator)) {
+            try {
+                final T next = iterator.next();
+                loaded.add(next);
+                logger.debug("Found type {}", type);
+            } catch (Exception e) {
+                logger.error("Could not load listener {}: {}", type, e.getMessage());
+            }
+        }
+        return loaded;
+    }
+
+    private static boolean nextSafely(final Iterator iterator) {
+        try {
+            return iterator.hasNext();
+        } catch (Exception e) {
+            logger.error("nextSafely failed", e);
+            return false;
+        }
+    }
+}

--- a/qase-java-commons/src/main/java/io/qase/commons/reporters/CoreReporter.java
+++ b/qase-java-commons/src/main/java/io/qase/commons/reporters/CoreReporter.java
@@ -6,6 +6,7 @@ import io.qase.commons.client.ApiClientV1;
 import io.qase.commons.client.ApiClientV2;
 import io.qase.commons.config.Mode;
 import io.qase.commons.config.QaseConfig;
+import io.qase.commons.hooks.HooksManager;
 import io.qase.commons.models.domain.TestResult;
 import io.qase.commons.writers.FileWriter;
 import io.qase.commons.writers.Writer;
@@ -20,12 +21,14 @@ public class CoreReporter implements Reporter {
 
     private InternalReporter reporter;
     private InternalReporter fallback;
+    private final HooksManager hooksManager;
 
     public CoreReporter(QaseConfig config) {
         logger.info("Qase config: {}", config);
 
         this.reporter = this.createReporter(config, config.mode);
         this.fallback = this.createReporter(config, config.fallback);
+        this.hooksManager = HooksManager.getDefaultHooksManager();
     }
 
     @Override
@@ -45,6 +48,8 @@ public class CoreReporter implements Reporter {
     @Override
     public void addResult(TestResult result) {
         logger.info("Adding result: {}", result);
+
+        this.hooksManager.beforeTestStop(result);
 
         executeWithFallback(() -> reporter.addResult(result), "add result");
     }

--- a/qase-junit4-reporter/pom.xml
+++ b/qase-junit4-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.9</version>
+        <version>4.0.10</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-junit4-reporter/src/main/java/io/qase/junit4/Qase.java
+++ b/qase-junit4-reporter/src/main/java/io/qase/junit4/Qase.java
@@ -14,4 +14,8 @@ public class Qase {
     public static void attach(String fileName, String content, String contentType) {
         Methods.addAttachment(fileName, content, contentType);
     }
+
+    public static void attach(String fileName, byte[] content, String contentType) {
+        Methods.addAttachment(fileName, content, contentType);
+    }
 }

--- a/qase-junit4-reporter/src/main/java/io/qase/junit4/QaseListener.java
+++ b/qase-junit4-reporter/src/main/java/io/qase/junit4/QaseListener.java
@@ -49,52 +49,28 @@ public class QaseListener extends RunListener {
     @Override
     public void testFinished(Description description) {
         if (addIfNotPresent(description)) {
-            TestResult result = this.stopTestCase(TestResultStatus.PASSED, null);
-
-            if (result == null) {
-                return;
-            }
-
-            this.qaseTestCaseListener.addResult(result);
+            this.stopTestCase(TestResultStatus.PASSED, null);
         }
     }
 
     @Override
     public void testFailure(Failure failure) {
         if (addIfNotPresent(failure.getDescription())) {
-            TestResult result = this.stopTestCase(TestResultStatus.FAILED, failure.getException());
-
-            if (result == null) {
-                return;
-            }
-
-            this.qaseTestCaseListener.addResult(result);
+            this.stopTestCase(TestResultStatus.FAILED, failure.getException());
         }
     }
 
     @Override
     public void testAssumptionFailure(Failure failure) {
         if (addIfNotPresent(failure.getDescription())) {
-            TestResult result = this.stopTestCase(TestResultStatus.FAILED, failure.getException());
-
-            if (result == null) {
-                return;
-            }
-
-            this.qaseTestCaseListener.addResult(result);
+            this.stopTestCase(TestResultStatus.FAILED, failure.getException());
         }
     }
 
     @Override
     public void testIgnored(Description description) {
         if (addIfNotPresent(description)) {
-            TestResult result = this.stopTestCase(TestResultStatus.SKIPPED, null);
-
-            if (result == null) {
-                return;
-            }
-
-            this.qaseTestCaseListener.addResult(result);
+            this.stopTestCase(TestResultStatus.SKIPPED, null);
         }
     }
 
@@ -146,11 +122,12 @@ public class QaseListener extends RunListener {
         return resultCreate;
     }
 
-    private TestResult stopTestCase(TestResultStatus status, Throwable error) {
+    private void stopTestCase(TestResultStatus status, Throwable error) {
         TestResult resultCreate = CasesStorage.getCurrentCase();
-        CasesStorage.stopCase();
+
         if (resultCreate.ignore) {
-            return null;
+            CasesStorage.stopCase();
+            return;
         }
 
         Optional<Throwable> resultThrowable = Optional.ofNullable(error);
@@ -172,7 +149,8 @@ public class QaseListener extends RunListener {
             }
         }
 
-        return resultCreate;
+        this.qaseTestCaseListener.addResult(resultCreate);
+        CasesStorage.stopCase();
     }
 
     private Long getCaseId(Description description) {

--- a/qase-junit5-reporter/pom.xml
+++ b/qase-junit5-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.9</version>
+        <version>4.0.10</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-junit5-reporter/src/main/java/io/qase/junit5/Qase.java
+++ b/qase-junit5-reporter/src/main/java/io/qase/junit5/Qase.java
@@ -14,4 +14,8 @@ public class Qase {
     public static void attach(String fileName, String content, String contentType) {
         Methods.addAttachment(fileName, content, contentType);
     }
+
+    public static void attach(String fileName, byte[] content, String contentType) {
+        Methods.addAttachment(fileName, content, contentType);
+    }
 }

--- a/qase-junit5-reporter/src/main/java/io/qase/junit5/QaseListener.java
+++ b/qase-junit5-reporter/src/main/java/io/qase/junit5/QaseListener.java
@@ -132,42 +132,25 @@ public class QaseListener implements TestExecutionListener, Extension, BeforeAll
 
     @Override
     public void testSuccessful(ExtensionContext context) {
-        TestResult result = this.stopTestCase(TestResultStatus.PASSED, null);
-
-        if (result == null) {
-            return;
-        }
-
-        this.qaseTestCaseListener.addResult(result);
+       this.stopTestCase(TestResultStatus.PASSED, null);
     }
 
     @Override
     public void testAborted(ExtensionContext context, Throwable cause) {
-        TestResult result = this.stopTestCase(TestResultStatus.SKIPPED, cause);
-
-        if (result == null) {
-            return;
-        }
-
-        this.qaseTestCaseListener.addResult(result);
+        this.stopTestCase(TestResultStatus.SKIPPED, cause);
     }
 
     @Override
     public void testFailed(ExtensionContext context, Throwable cause) {
-        TestResult result = this.stopTestCase(TestResultStatus.FAILED, cause);
-
-        if (result == null) {
-            return;
-        }
-
-        this.qaseTestCaseListener.addResult(result);
+        this.stopTestCase(TestResultStatus.FAILED, cause);
     }
 
-    private TestResult stopTestCase(TestResultStatus status, Throwable cause) {
+    private void stopTestCase(TestResultStatus status, Throwable cause) {
         TestResult resultCreate = CasesStorage.getCurrentCase();
-        CasesStorage.stopCase();
+
         if (resultCreate.ignore) {
-            return null;
+            CasesStorage.stopCase();
+            return;
         }
 
         Optional<Throwable> resultThrowable = Optional.ofNullable(cause);
@@ -189,6 +172,7 @@ public class QaseListener implements TestExecutionListener, Extension, BeforeAll
             }
         }
 
-        return resultCreate;
+        this.qaseTestCaseListener.addResult(resultCreate);
+        CasesStorage.stopCase();
     }
 }

--- a/qase-testng-reporter/pom.xml
+++ b/qase-testng-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.9</version>
+        <version>4.0.10</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-testng-reporter/src/main/java/io/qase/testng/Qase.java
+++ b/qase-testng-reporter/src/main/java/io/qase/testng/Qase.java
@@ -14,4 +14,8 @@ public class Qase {
     public static void attach(String fileName, String content, String contentType) {
         Methods.addAttachment(fileName, content, contentType);
     }
+
+    public static void attach(String fileName, byte[] content, String contentType) {
+        Methods.addAttachment(fileName, content, contentType);
+    }
 }

--- a/qase-testng-reporter/src/main/java/io/qase/testng/QaseListener.java
+++ b/qase-testng-reporter/src/main/java/io/qase/testng/QaseListener.java
@@ -48,42 +48,24 @@ public class QaseListener implements ISuiteListener,
 
     @Override
     public void onTestSuccess(ITestResult tr) {
-        TestResult result = this.stopTestCase(tr, TestResultStatus.PASSED);
-
-        if (result == null) {
-            return;
-        }
-
-        this.qaseTestCaseListener.addResult(result);
+        this.stopTestCase(tr, TestResultStatus.PASSED);
     }
 
     @Override
     public void onTestFailure(ITestResult tr) {
-        TestResult result = this.stopTestCase(tr, TestResultStatus.FAILED);
-
-        if (result == null) {
-            return;
-        }
-
-        this.qaseTestCaseListener.addResult(result);
+        this.stopTestCase(tr, TestResultStatus.FAILED);
     }
 
     @Override
     public void onTestSkipped(ITestResult tr) {
-        TestResult result = this.stopTestCase(tr, TestResultStatus.SKIPPED);
-
-        if (result == null) {
-            return;
-        }
-
-        this.qaseTestCaseListener.addResult(result);
+        this.stopTestCase(tr, TestResultStatus.SKIPPED);
     }
 
-    private TestResult stopTestCase(ITestResult result, TestResultStatus status) {
+    private void stopTestCase(ITestResult result, TestResultStatus status) {
         TestResult resultCreate = CasesStorage.getCurrentCase();
-        CasesStorage.stopCase();
         if (resultCreate.ignore) {
-            return null;
+            CasesStorage.stopCase();
+            return;
         }
 
         Optional<Throwable> resultThrowable = Optional.ofNullable(result.getThrowable());
@@ -105,7 +87,8 @@ public class QaseListener implements ISuiteListener,
             }
         }
 
-        return resultCreate;
+        this.qaseTestCaseListener.addResult(resultCreate);
+        CasesStorage.stopCase();
     }
 
     private TestResult startTestCase(ITestResult result) {


### PR DESCRIPTION
This pull request updates the `qase-java` library to version 4.0.10 and introduces a new feature for executing custom hooks before a test completes. Additionally, it includes various improvements and refactorings across multiple modules.

### Version Update:
* Updated the version from 4.0.9 to 4.0.10 in `pom.xml` files for multiple modules. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L10-R10) [[2]](diffhunk://#diff-514718fdfdacca86f2493ed9c6b28cc51a1345d76c874502fac7f18fb2281ac3L8-R8) [[3]](diffhunk://#diff-b2f841fbc79604c93661caea3c4160164f6067df2d25120c4525a3cadb4298d4L9-R9) [[4]](diffhunk://#diff-52c515b32b1f02b9f152f58e3e0e18a219cb44a72102b327c800d746db5fc8dcL8-R8) [[5]](diffhunk://#diff-86b8d7f9216c05d31872fdbe761c485f366052ebe73550b87426703a2aa75641L8-R8) [[6]](diffhunk://#diff-2a13ac9cd6493cd0ee2b5f04cbdf7468938e3b1e7265bac614812a75ba4ee713L8-R8) [[7]](diffhunk://#diff-8dca3b4b2c0f85527d8bbf623069a53ae88d17ff67f00c67b71a1806199886adL8-R8) [[8]](diffhunk://#diff-b14d9176febd68d8f2592505f4cad251e87e159ae3b1d07778ffea38abcc0ec9L8-R8) [[9]](diffhunk://#diff-79a1b271637ed57e83005174230b63752c7e9165c49d2d19daae2a57c8d85bc7L8-R8) [[10]](diffhunk://#diff-c37a1a3bee150a3b54679b00ff4e69fbfa400fba50dc3d14a9c7a15571ca0039L8-R8) [[11]](diffhunk://#diff-fd60886a06671d6036def9287c94fe81b41d8febdd96e19da87d65aefbf36bdaL9-R9)

### New Feature:
* Introduced the ability to execute custom hooks before a test completes, allowing users to run custom code at the end of test execution.

### Documentation:
* Added a new section in `qase-java-commons/README.md` explaining how to add an attachment for a failed test using the `HooksListener` interface.

### Code Enhancements:
* Added new interfaces and classes to support the custom hooks feature:
  * `DefaultListener` interface in `qase-java-commons/src/main/java/io/qase/commons/hooks/DefaultListener.java`
  * `HooksListener` interface in `qase-java-commons/src/main/java/io/qase/commons/hooks/HooksListener.java`
  * `HooksManager` class in `qase-java-commons/src/main/java/io/qase/commons/hooks/HooksManager.java`
  * `HooksServiceLoader` class in `qase-java-commons/src/main/java/io/qase/commons/hooks/HooksServiceLoader.java`

### Refactoring:
* Refactored `CoreReporter` class to integrate the `HooksManager` for executing hooks before test completion. [[1]](diffhunk://#diff-ea52f4e963a18ed18d5484c75f9c4c9db5401205be988361560fc19874bbf1adR9) [[2]](diffhunk://#diff-ea52f4e963a18ed18d5484c75f9c4c9db5401205be988361560fc19874bbf1adR24-R31) [[3]](diffhunk://#diff-ea52f4e963a18ed18d5484c75f9c4c9db5401205be988361560fc19874bbf1adR52-R53)
* Simplified the `QaseListener` class in the `qase-junit4-reporter` module by removing redundant code and ensuring test results are added after stopping the test case. [[1]](diffhunk://#diff-213669ff364b67b454a7282f5f821c19e57591552615edbd24bdd04bfb82577aL52-R73) [[2]](diffhunk://#diff-213669ff364b67b454a7282f5f821c19e57591552615edbd24bdd04bfb82577aL149-R130) [[3]](diffhunk://#diff-213669ff364b67b454a7282f5f821c19e57591552615edbd24bdd04bfb82577aL175-R153)
* Added a new method to attach files in `Qase` class in the `qase-junit4-reporter` module.