### PR TITLE
feat: add local time support for test runs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+# qase-java 4.0.11
+
+## What's new
+
+Implemented local time support for test run creation to improve time tracking.
+
 # qase-java 4.0.10
 
 ## What's new

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.qase</groupId>
     <artifactId>qase-java</artifactId>
     <packaging>pom</packaging>
-    <version>4.0.10</version>
+    <version>4.0.11</version>
     <modules>
         <module>qase-java-commons</module>
         <module>qase-api-client</module>

--- a/qase-api-client/pom.xml
+++ b/qase-api-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.10</version>
+        <version>4.0.11</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-api-v2-client/pom.xml
+++ b/qase-api-v2-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.qase</groupId>
         <artifactId>qase-java</artifactId>
-        <version>4.0.10</version>
+        <version>4.0.11</version>
     </parent>
 
     <artifactId>qase-api-v2-client</artifactId>

--- a/qase-cucumber-v3-reporter/pom.xml
+++ b/qase-cucumber-v3-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.10</version>
+        <version>4.0.11</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v4-reporter/pom.xml
+++ b/qase-cucumber-v4-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.10</version>
+        <version>4.0.11</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v5-reporter/pom.xml
+++ b/qase-cucumber-v5-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.10</version>
+        <version>4.0.11</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v6-reporter/pom.xml
+++ b/qase-cucumber-v6-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.10</version>
+        <version>4.0.11</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v7-reporter/pom.xml
+++ b/qase-cucumber-v7-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.10</version>
+        <version>4.0.11</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-java-commons/pom.xml
+++ b/qase-java-commons/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.qase</groupId>
         <artifactId>qase-java</artifactId>
-        <version>4.0.10</version>
+        <version>4.0.11</version>
     </parent>
 
     <artifactId>qase-java-commons</artifactId>

--- a/qase-java-commons/src/main/java/io/qase/commons/client/ApiClientV1.java
+++ b/qase-java-commons/src/main/java/io/qase/commons/client/ApiClientV1.java
@@ -24,6 +24,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 
 /**
  * Qase API V1 client
@@ -53,9 +57,13 @@ public class ApiClientV1 implements io.qase.commons.client.ApiClient {
 
     @Override
     public Long createTestRun() throws QaseException {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+        String utcTime = ZonedDateTime.ofInstant(Instant.now(), ZoneId.of("UTC")).format(formatter);
+
         RunCreate model = new RunCreate()
                 .title(this.config.testops.run.title)
-                .isAutotest(true);
+                .isAutotest(true)
+                .startTime(utcTime);
 
         if (this.config.testops.run.description != null) {
             model.setDescription(this.config.testops.run.description);

--- a/qase-junit4-reporter/pom.xml
+++ b/qase-junit4-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.10</version>
+        <version>4.0.11</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-junit5-reporter/pom.xml
+++ b/qase-junit5-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.10</version>
+        <version>4.0.11</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-testng-reporter/pom.xml
+++ b/qase-testng-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.0.10</version>
+        <version>4.0.11</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
This pull request includes updates to the `qase-java` project, primarily focusing on version upgrades and the addition of local time support for test run creation. The most important changes are summarized below:

### Version Upgrades:
* Updated the version from `4.0.10` to `4.0.11` in the main `pom.xml` file and all module `pom.xml` files to ensure consistency across the project. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L10-R10) [[2]](diffhunk://#diff-514718fdfdacca86f2493ed9c6b28cc51a1345d76c874502fac7f18fb2281ac3L8-R8) [[3]](diffhunk://#diff-b2f841fbc79604c93661caea3c4160164f6067df2d25120c4525a3cadb4298d4L9-R9) [[4]](diffhunk://#diff-52c515b32b1f02b9f152f58e3e0e18a219cb44a72102b327c800d746db5fc8dcL8-R8) [[5]](diffhunk://#diff-86b8d7f9216c05d31872fdbe761c485f366052ebe73550b87426703a2aa75641L8-R8) [[6]](diffhunk://#diff-2a13ac9cd6493cd0ee2b5f04cbdf7468938e3b1e7265bac614812a75ba4ee713L8-R8) [[7]](diffhunk://#diff-8dca3b4b2c0f85527d8bbf623069a53ae88d17ff67f00c67b71a1806199886adL8-R8) [[8]](diffhunk://#diff-b14d9176febd68d8f2592505f4cad251e87e159ae3b1d07778ffea38abcc0ec9L8-R8) [[9]](diffhunk://#diff-fd60886a06671d6036def9287c94fe81b41d8febdd96e19da87d65aefbf36bdaL9-R9) [[10]](diffhunk://#diff-79a1b271637ed57e83005174230b63752c7e9165c49d2d19daae2a57c8d85bc7L8-R8) [[11]](diffhunk://#diff-c37a1a3bee150a3b54679b00ff4e69fbfa400fba50dc3d14a9c7a15571ca0039L8-R8) [[12]](diffhunk://#diff-2d7da0f3d513459b39793e52a7e3ffb2d05af6c1f851b303fe68ef7815db7814L8-R8)

### Feature Addition:
* Implemented local time support for test run creation to improve time tracking by adding the current UTC time as the start time of the test run. This change includes importing necessary time-related classes and updating the `createTestRun` method in `ApiClientV1.java`. [[1]](diffhunk://#diff-e8f0c158c138dae8c37de4b8c5c26f69c10eb5adac3d26454c5606a0ffcc5a10R27-R30) [[2]](diffhunk://#diff-e8f0c158c138dae8c37de4b8c5c26f69c10eb5adac3d26454c5606a0ffcc5a10R60-R66)

### Documentation:
* Updated the `changelog.md` file to reflect the new version `4.0.11` and describe the addition of local time support for test run creation.