### PR TITLE
fix: correct handling of nested suites and improve logging

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,10 @@
+# qase-java 4.1.2
+
+## What's new
+
+- Resolved issue with handling of nested (child) suites in Cucumber reporters
+- Enhanced logging to provide more detailed and clear output during test execution
+
 # qase-java 4.1.1
 
 ## What's new

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.qase</groupId>
     <artifactId>qase-java</artifactId>
     <packaging>pom</packaging>
-    <version>4.1.1</version>
+    <version>4.1.2</version>
     <modules>
         <module>qase-java-commons</module>
         <module>qase-api-client</module>

--- a/qase-api-client/pom.xml
+++ b/qase-api-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.1</version>
+        <version>4.1.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-api-v2-client/pom.xml
+++ b/qase-api-v2-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.qase</groupId>
         <artifactId>qase-java</artifactId>
-        <version>4.1.1</version>
+        <version>4.1.2</version>
     </parent>
 
     <artifactId>qase-api-v2-client</artifactId>

--- a/qase-cucumber-v3-reporter/pom.xml
+++ b/qase-cucumber-v3-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.1</version>
+        <version>4.1.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v3-reporter/src/main/java/io/qase/cucumber3/QaseEventListener.java
+++ b/qase-cucumber-v3-reporter/src/main/java/io/qase/cucumber3/QaseEventListener.java
@@ -104,7 +104,7 @@ public class QaseEventListener implements Formatter {
         String suite = CucumberUtils.getCaseSuite(tags);
         Relations relations = new Relations();
         if (suite != null) {
-            String[] parts = suite.split("\t");
+            String[] parts = suite.split("\\\\t");
             for (String part : parts) {
                 SuiteData data = new SuiteData();
                 data.title = part;

--- a/qase-cucumber-v4-reporter/pom.xml
+++ b/qase-cucumber-v4-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.1</version>
+        <version>4.1.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v4-reporter/src/main/java/io/qase/cucumber4/QaseEventListener.java
+++ b/qase-cucumber-v4-reporter/src/main/java/io/qase/cucumber4/QaseEventListener.java
@@ -103,7 +103,7 @@ public class QaseEventListener implements ConcurrentEventListener {
         String suite = CucumberUtils.getCaseSuite(tags);
         Relations relations = new Relations();
         if (suite != null) {
-            String[] parts = suite.split("\t");
+            String[] parts = suite.split("\\\\t");
             for (String part : parts) {
                 SuiteData data = new SuiteData();
                 data.title = part;

--- a/qase-cucumber-v5-reporter/pom.xml
+++ b/qase-cucumber-v5-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.1</version>
+        <version>4.1.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v5-reporter/src/main/java/io/qase/cucumber5/QaseEventListener.java
+++ b/qase-cucumber-v5-reporter/src/main/java/io/qase/cucumber5/QaseEventListener.java
@@ -94,7 +94,7 @@ public class QaseEventListener implements ConcurrentEventListener {
         String suite = CucumberUtils.getCaseSuite(tags);
         Relations relations = new Relations();
         if (suite != null) {
-            String[] parts = suite.split("\t");
+            String[] parts = suite.split("\\\\t");
             for (String part : parts) {
                 SuiteData data = new SuiteData();
                 data.title = part;

--- a/qase-cucumber-v6-reporter/pom.xml
+++ b/qase-cucumber-v6-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.1</version>
+        <version>4.1.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v6-reporter/src/main/java/io/qase/cucumber6/QaseEventListener.java
+++ b/qase-cucumber-v6-reporter/src/main/java/io/qase/cucumber6/QaseEventListener.java
@@ -94,7 +94,7 @@ public class QaseEventListener implements ConcurrentEventListener {
         String suite = CucumberUtils.getCaseSuite(tags);
         Relations relations = new Relations();
         if (suite != null) {
-            String[] parts = suite.split("\t");
+            String[] parts = suite.split("\\\\t");
             for (String part : parts) {
                 SuiteData data = new SuiteData();
                 data.title = part;

--- a/qase-cucumber-v7-reporter/pom.xml
+++ b/qase-cucumber-v7-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.1</version>
+        <version>4.1.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v7-reporter/src/main/java/io/qase/cucumber7/QaseEventListener.java
+++ b/qase-cucumber-v7-reporter/src/main/java/io/qase/cucumber7/QaseEventListener.java
@@ -94,7 +94,7 @@ public class QaseEventListener implements ConcurrentEventListener {
         String suite = CucumberUtils.getCaseSuite(tags);
         Relations relations = new Relations();
         if (suite != null) {
-            String[] parts = suite.split("\t");
+            String[] parts = suite.split("\\\\t");
             for (String part : parts) {
                 SuiteData data = new SuiteData();
                 data.title = part;

--- a/qase-java-commons/pom.xml
+++ b/qase-java-commons/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.qase</groupId>
         <artifactId>qase-java</artifactId>
-        <version>4.1.1</version>
+        <version>4.1.2</version>
     </parent>
 
     <artifactId>qase-java-commons</artifactId>

--- a/qase-java-commons/src/main/java/io/qase/commons/reporters/CoreReporter.java
+++ b/qase-java-commons/src/main/java/io/qase/commons/reporters/CoreReporter.java
@@ -43,7 +43,7 @@ public class CoreReporter implements Reporter {
 
     @Override
     public void addResult(TestResult result) {
-        logger.info("Adding result: %s", result);
+        logger.debug("Adding result: %s", result);
 
         this.hooksManager.beforeTestStop(result);
 

--- a/qase-junit4-reporter/pom.xml
+++ b/qase-junit4-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.1</version>
+        <version>4.1.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-junit5-reporter/pom.xml
+++ b/qase-junit5-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.1</version>
+        <version>4.1.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-testng-reporter/pom.xml
+++ b/qase-testng-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.1</version>
+        <version>4.1.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
This pull request includes updates to the `qase-java` library, specifically version 4.1.2. The changes address issues with nested suite handling in Cucumber reporters and enhance logging during test execution. Additionally, multiple `pom.xml` files have been updated to reflect the new version.

### Key Changes:

**Enhancements and Bug Fixes:**
* Resolved issue with handling of nested (child) suites in Cucumber reporters.
* Enhanced logging to provide more detailed and clear output during test execution.

**Version Updates:**
* Updated version from 4.1.1 to 4.1.2 in `pom.xml` files across multiple modules:
  * `qase-java`
  * `qase-api-client`
  * `qase-api-v2-client`
  * `qase-cucumber-v3-reporter`
  * `qase-cucumber-v4-reporter`
  * `qase-cucumber-v5-reporter`
  * `qase-cucumber-v6-reporter`
  * `qase-cucumber-v7-reporter`
  * `qase-java-commons`
  * `qase-junit4-reporter`
  * `qase-junit5-reporter`
  * `qase-testng-reporter`

**Code Improvements:**
* Fixed the split pattern for handling tabs in suite names across multiple Cucumber reporter versions:
  * `qase-cucumber-v3-reporter`
  * `qase-cucumber-v4-reporter`
  * `qase-cucumber-v5-reporter`
  * `qase-cucumber-v6-reporter`
  * `qase-cucumber-v7-reporter`
* Changed logging level for adding test results from `info` to `debug` in `CoreReporter.java`.