### PR TITLE
feat(cucumber): add support for step parameters and table argument rendering

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,9 +1,17 @@
+# qase-java 4.1.4
+
+## What's new
+
+Added support for step parameters and table arguments in Cucumber reporters. Step definitions with arguments and
+tabular data are now correctly captured and displayed in test results.
+
 # qase-java 4.1.3
 
 ## What's new
 
 - Resolved issue with serialization of models containing fields not described in the OpenAPI specification.
-- Unspecified fields are now properly handled and stored in `additionalProperties` to ensure compatibility with dynamic payloads.
+- Unspecified fields are now properly handled and stored in `additionalProperties` to ensure compatibility with dynamic
+  payloads.
 
 # qase-java 4.1.2
 
@@ -45,7 +53,8 @@ Implemented local time support for test run creation to improve time tracking.
 ## What's new
 
 Introduced the ability to execute custom hooks before a test completes, allowing users to run custom code at the end of
-test execution. More details can be found in the [documentation](https://github.com/qase-tms/qase-java/tree/main/qase-java-commons#readme)
+test execution. More details can be found in
+the [documentation](https://github.com/qase-tms/qase-java/tree/main/qase-java-commons#readme)
 
 # qase-java 4.0.9
 

--- a/examples/cucubmer7/cucumber7-gradle-junit4/src/test/java/org/example/Steps.java
+++ b/examples/cucubmer7/cucumber7-gradle-junit4/src/test/java/org/example/Steps.java
@@ -1,5 +1,7 @@
 package org.example;
 
+import io.cucumber.datatable.DataTable;
+import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import io.qase.cucumber7.Qase;
@@ -29,5 +31,20 @@ public class Steps {
     @When("add attachments from content")
     public void addAttachmentsContent() {
         Qase.attach("file.txt", "Content", "text/plain");
+    }
+
+    @Given("I have a parameter {word}")
+    public void iHaveAParameter(String parameter) {
+        System.out.println("Parameter: " + parameter);
+    }
+
+    @When("I do something with the parameter")
+    public void iDoSomethingWithTheParameter(DataTable dataTable) {
+        System.out.println("Doing something with the parameter...");
+    }
+
+    @Then("I should see the result")
+    public void iShouldSeeTheResult() {
+        System.out.println("Result is displayed.");
     }
 }

--- a/examples/cucubmer7/cucumber7-gradle-junit4/src/test/resources/features/params-tests.feature
+++ b/examples/cucubmer7/cucumber7-gradle-junit4/src/test/resources/features/params-tests.feature
@@ -1,0 +1,15 @@
+Feature: Parameterized tests
+
+  Scenario Outline: Test with parameters
+    Given I have a parameter <param>
+    When I do something with the parameter
+      | transaction | types          |
+      | transfer    | manual, mobile |
+      | inward      | manual, mobile |
+    Then I should see the result
+
+    Examples:
+      | param  |
+      | value1 |
+      | value2 |
+      | value3 |

--- a/examples/cucubmer7/cucumber7-gradle-junit5/src/test/java/org/example/Steps.java
+++ b/examples/cucubmer7/cucumber7-gradle-junit5/src/test/java/org/example/Steps.java
@@ -1,5 +1,7 @@
 package org.example;
 
+import io.cucumber.datatable.DataTable;
+import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import io.qase.cucumber7.Qase;
@@ -29,5 +31,20 @@ public class Steps {
     @When("add attachments from content")
     public void addAttachmentsContent() {
         Qase.attach("file.txt", "Content", "text/plain");
+    }
+
+    @Given("I have a parameter {word}")
+    public void iHaveAParameter(String parameter) {
+        System.out.println("Parameter: " + parameter);
+    }
+
+    @When("I do something with the parameter")
+    public void iDoSomethingWithTheParameter(DataTable dataTable) {
+        System.out.println("Doing something with the parameter...");
+    }
+
+    @Then("I should see the result")
+    public void iShouldSeeTheResult() {
+        System.out.println("Result is displayed.");
     }
 }

--- a/examples/cucubmer7/cucumber7-gradle-junit5/src/test/resources/features/params-tests.feature
+++ b/examples/cucubmer7/cucumber7-gradle-junit5/src/test/resources/features/params-tests.feature
@@ -1,0 +1,15 @@
+Feature: Parameterized tests
+
+  Scenario Outline: Test with parameters
+    Given I have a parameter <param>
+    When I do something with the parameter
+      | transaction | types          |
+      | transfer    | manual, mobile |
+      | inward      | manual, mobile |
+    Then I should see the result
+
+    Examples:
+      | param  |
+      | value1 |
+      | value2 |
+      | value3 |

--- a/examples/cucubmer7/cucumber7-gradle-testng/src/test/java/org/example/Steps.java
+++ b/examples/cucubmer7/cucumber7-gradle-testng/src/test/java/org/example/Steps.java
@@ -1,5 +1,7 @@
 package org.example;
 
+import io.cucumber.datatable.DataTable;
+import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import io.qase.cucumber7.Qase;
@@ -29,5 +31,20 @@ public class Steps {
     @When("add attachments from content")
     public void addAttachmentsContent() {
         Qase.attach("file.txt", "Content", "text/plain");
+    }
+
+    @Given("I have a parameter {word}")
+    public void iHaveAParameter(String parameter) {
+        System.out.println("Parameter: " + parameter);
+    }
+
+    @When("I do something with the parameter")
+    public void iDoSomethingWithTheParameter(DataTable dataTable) {
+        System.out.println("Doing something with the parameter...");
+    }
+
+    @Then("I should see the result")
+    public void iShouldSeeTheResult() {
+        System.out.println("Result is displayed.");
     }
 }

--- a/examples/cucubmer7/cucumber7-gradle-testng/src/test/resources/features/params-tests.feature
+++ b/examples/cucubmer7/cucumber7-gradle-testng/src/test/resources/features/params-tests.feature
@@ -1,0 +1,15 @@
+Feature: Parameterized tests
+
+  Scenario Outline: Test with parameters
+    Given I have a parameter <param>
+    When I do something with the parameter
+      | transaction | types          |
+      | transfer    | manual, mobile |
+      | inward      | manual, mobile |
+    Then I should see the result
+
+    Examples:
+      | param  |
+      | value1 |
+      | value2 |
+      | value3 |

--- a/examples/cucubmer7/cucumber7-gradlekts-junit5/src/test/java/org/example/Steps.java
+++ b/examples/cucubmer7/cucumber7-gradlekts-junit5/src/test/java/org/example/Steps.java
@@ -1,5 +1,7 @@
 package org.example;
 
+import io.cucumber.datatable.DataTable;
+import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import io.qase.cucumber7.Qase;
@@ -29,5 +31,20 @@ public class Steps {
     @When("add attachments from content")
     public void addAttachmentsContent() {
         Qase.attach("file.txt", "Content", "text/plain");
+    }
+
+    @Given("I have a parameter {word}")
+    public void iHaveAParameter(String parameter) {
+        System.out.println("Parameter: " + parameter);
+    }
+
+    @When("I do something with the parameter")
+    public void iDoSomethingWithTheParameter(DataTable dataTable) {
+        System.out.println("Doing something with the parameter...");
+    }
+
+    @Then("I should see the result")
+    public void iShouldSeeTheResult() {
+        System.out.println("Result is displayed.");
     }
 }

--- a/examples/cucubmer7/cucumber7-gradlekts-junit5/src/test/resources/features/params-tests.feature
+++ b/examples/cucubmer7/cucumber7-gradlekts-junit5/src/test/resources/features/params-tests.feature
@@ -1,0 +1,15 @@
+Feature: Parameterized tests
+
+  Scenario Outline: Test with parameters
+    Given I have a parameter <param>
+    When I do something with the parameter
+      | transaction | types          |
+      | transfer    | manual, mobile |
+      | inward      | manual, mobile |
+    Then I should see the result
+
+    Examples:
+      | param  |
+      | value1 |
+      | value2 |
+      | value3 |

--- a/examples/cucubmer7/cucumber7-maven-junit4/src/test/java/org/example/Steps.java
+++ b/examples/cucubmer7/cucumber7-maven-junit4/src/test/java/org/example/Steps.java
@@ -1,5 +1,7 @@
 package org.example;
 
+import io.cucumber.datatable.DataTable;
+import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import io.qase.cucumber7.Qase;
@@ -29,5 +31,20 @@ public class Steps {
     @When("add attachments from content")
     public void addAttachmentsContent() {
         Qase.attach("file.txt", "Content", "text/plain");
+    }
+
+    @Given("I have a parameter {word}")
+    public void iHaveAParameter(String parameter) {
+        System.out.println("Parameter: " + parameter);
+    }
+
+    @When("I do something with the parameter")
+    public void iDoSomethingWithTheParameter(DataTable dataTable) {
+        System.out.println("Doing something with the parameter...");
+    }
+
+    @Then("I should see the result")
+    public void iShouldSeeTheResult() {
+        System.out.println("Result is displayed.");
     }
 }

--- a/examples/cucubmer7/cucumber7-maven-junit4/src/test/resources/features/params-tests.feature
+++ b/examples/cucubmer7/cucumber7-maven-junit4/src/test/resources/features/params-tests.feature
@@ -1,0 +1,15 @@
+Feature: Parameterized tests
+
+  Scenario Outline: Test with parameters
+    Given I have a parameter <param>
+    When I do something with the parameter
+      | transaction | types          |
+      | transfer    | manual, mobile |
+      | inward      | manual, mobile |
+    Then I should see the result
+
+    Examples:
+      | param  |
+      | value1 |
+      | value2 |
+      | value3 |

--- a/examples/cucubmer7/cucumber7-maven-junit5/src/test/java/org/example/Steps.java
+++ b/examples/cucubmer7/cucumber7-maven-junit5/src/test/java/org/example/Steps.java
@@ -1,5 +1,7 @@
 package org.example;
 
+import io.cucumber.datatable.DataTable;
+import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import io.qase.cucumber7.Qase;
@@ -29,5 +31,20 @@ public class Steps {
     @When("add attachments from content")
     public void addAttachmentsContent() {
         Qase.attach("file.txt", "Content", "text/plain");
+    }
+
+    @Given("I have a parameter {word}")
+    public void iHaveAParameter(String parameter) {
+        System.out.println("Parameter: " + parameter);
+    }
+
+    @When("I do something with the parameter")
+    public void iDoSomethingWithTheParameter(DataTable dataTable) {
+        System.out.println("Doing something with the parameter...");
+    }
+
+    @Then("I should see the result")
+    public void iShouldSeeTheResult() {
+        System.out.println("Result is displayed.");
     }
 }

--- a/examples/cucubmer7/cucumber7-maven-junit5/src/test/resources/features/params-tests.feature
+++ b/examples/cucubmer7/cucumber7-maven-junit5/src/test/resources/features/params-tests.feature
@@ -1,0 +1,15 @@
+Feature: Parameterized tests
+
+  Scenario Outline: Test with parameters
+    Given I have a parameter <param>
+    When I do something with the parameter
+      | transaction | types          |
+      | transfer    | manual, mobile |
+      | inward      | manual, mobile |
+    Then I should see the result
+
+    Examples:
+      | param  |
+      | value1 |
+      | value2 |
+      | value3 |

--- a/examples/cucubmer7/cucumber7-maven-testng/src/test/java/org/example/Steps.java
+++ b/examples/cucubmer7/cucumber7-maven-testng/src/test/java/org/example/Steps.java
@@ -1,5 +1,7 @@
 package org.example;
 
+import io.cucumber.datatable.DataTable;
+import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import io.qase.cucumber7.Qase;
@@ -29,5 +31,20 @@ public class Steps {
     @When("add attachments from content")
     public void addAttachmentsContent() {
         Qase.attach("file.txt", "Content", "text/plain");
+    }
+
+    @Given("I have a parameter {word}")
+    public void iHaveAParameter(String parameter) {
+        System.out.println("Parameter: " + parameter);
+    }
+
+    @When("I do something with the parameter")
+    public void iDoSomethingWithTheParameter(DataTable dataTable) {
+        System.out.println("Doing something with the parameter...");
+    }
+
+    @Then("I should see the result")
+    public void iShouldSeeTheResult() {
+        System.out.println("Result is displayed.");
     }
 }

--- a/examples/cucubmer7/cucumber7-maven-testng/src/test/resources/features/params-tests.feature
+++ b/examples/cucubmer7/cucumber7-maven-testng/src/test/resources/features/params-tests.feature
@@ -1,0 +1,15 @@
+Feature: Parameterized tests
+
+  Scenario Outline: Test with parameters
+    Given I have a parameter <param>
+    When I do something with the parameter
+      | transaction | types          |
+      | transfer    | manual, mobile |
+      | inward      | manual, mobile |
+    Then I should see the result
+
+    Examples:
+      | param  |
+      | value1 |
+      | value2 |
+      | value3 |

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.qase</groupId>
     <artifactId>qase-java</artifactId>
     <packaging>pom</packaging>
-    <version>4.1.3</version>
+    <version>4.1.4</version>
     <modules>
         <module>qase-java-commons</module>
         <module>qase-api-client</module>

--- a/qase-api-client/pom.xml
+++ b/qase-api-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.3</version>
+        <version>4.1.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-api-v2-client/pom.xml
+++ b/qase-api-v2-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.qase</groupId>
         <artifactId>qase-java</artifactId>
-        <version>4.1.3</version>
+        <version>4.1.4</version>
     </parent>
 
     <artifactId>qase-api-v2-client</artifactId>

--- a/qase-cucumber-v3-reporter/pom.xml
+++ b/qase-cucumber-v3-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.3</version>
+        <version>4.1.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v3-reporter/src/main/java/io/qase/cucumber3/QaseEventListener.java
+++ b/qase-cucumber-v3-reporter/src/main/java/io/qase/cucumber3/QaseEventListener.java
@@ -2,8 +2,13 @@ package io.qase.cucumber3;
 
 import cucumber.api.PickleStepTestStep;
 import cucumber.api.Result;
+import cucumber.api.TestCase;
 import cucumber.api.event.*;
 import cucumber.api.formatter.Formatter;
+import gherkin.ast.Examples;
+import gherkin.ast.ScenarioDefinition;
+import gherkin.ast.ScenarioOutline;
+import gherkin.ast.TableRow;
 import gherkin.pickles.PickleTag;
 import io.qase.commons.CasesStorage;
 import io.qase.commons.StepStorage;
@@ -14,30 +19,35 @@ import io.qase.commons.reporters.Reporter;
 import okio.Path;
 
 import java.time.Instant;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static io.qase.commons.utils.IntegrationUtils.getStacktrace;
 
 public class QaseEventListener implements Formatter {
 
     private final Reporter qaseTestCaseListener;
+    private final ScenarioStorage scenarioStorage;
 
     public QaseEventListener() {
         this.qaseTestCaseListener = CoreReporterFactory.getInstance();
+        this.scenarioStorage = new ScenarioStorage();
     }
 
     @Override
     public void setEventPublisher(EventPublisher publisher) {
+        publisher.registerHandlerFor(TestSourceRead.class, this::scenarioRead);
         publisher.registerHandlerFor(TestCaseStarted.class, this::testCaseStarted);
         publisher.registerHandlerFor(TestCaseFinished.class, this::testCaseFinished);
         publisher.registerHandlerFor(TestRunStarted.class, this::testRunStarted);
         publisher.registerHandlerFor(TestRunFinished.class, this::testRunFinished);
         publisher.registerHandlerFor(TestStepStarted.class, this::testStepStarted);
         publisher.registerHandlerFor(TestStepFinished.class, this::testStepFinished);
+    }
 
+    private void scenarioRead(TestSourceRead event) {
+        this.scenarioStorage.addScenarioEvent(event.uri, event);
     }
 
     private void testRunStarted(TestRunStarted testRunStarted) {
@@ -93,6 +103,15 @@ public class QaseEventListener implements Formatter {
         if (ignore) {
             resultCreate.ignore = true;
             return resultCreate;
+        }
+
+        final ScenarioDefinition scenarioDefinition = ScenarioStorage.getScenarioDefinition(scenarioStorage.getCucumberNode(event.testCase.getUri(), event.testCase.getLine()));
+
+        Map<String, String> parameters = new HashMap<>();
+
+        if (scenarioDefinition instanceof ScenarioOutline) {
+            parameters =
+                    getExamplesAsParameters((ScenarioOutline) scenarioDefinition, event.testCase);
         }
 
         List<Long> caseIds = CucumberUtils.getCaseIds(tags);
@@ -179,6 +198,33 @@ public class QaseEventListener implements Formatter {
             case SKIPPED:
             default:
                 return StepResultStatus.BLOCKED;
+        }
+    }
+
+    private Map<String, String> getExamplesAsParameters(
+            final ScenarioOutline scenarioOutline, final TestCase localCurrentTestCase
+    ) {
+        final Optional<Examples> examplesBlock =
+                scenarioOutline.getExamples().stream()
+                        .filter(example -> example.getTableBody().stream()
+                                .anyMatch(row -> row.getLocation().getLine() == localCurrentTestCase.getLine())
+                        ).findFirst();
+
+        if (examplesBlock.isPresent()) {
+            final TableRow row = examplesBlock.get().getTableBody().stream()
+                    .filter(example -> example.getLocation().getLine() == localCurrentTestCase.getLine())
+                    .findFirst().get();
+            final Map<String, String> parameters = new HashMap<>();
+
+            IntStream.range(0, examplesBlock.get().getTableHeader().getCells().size()).forEach(index -> {
+                final String name = examplesBlock.get().getTableHeader().getCells().get(index).getValue();
+                final String value = row.getCells().get(index).getValue();
+                parameters.put(name, value);
+            });
+
+            return parameters;
+        } else {
+            return Collections.emptyMap();
         }
     }
 }

--- a/qase-cucumber-v3-reporter/src/main/java/io/qase/cucumber3/ScenarioStorage.java
+++ b/qase-cucumber-v3-reporter/src/main/java/io/qase/cucumber3/ScenarioStorage.java
@@ -1,0 +1,117 @@
+package io.qase.cucumber3;
+
+import cucumber.api.event.TestSourceRead;
+import gherkin.AstBuilder;
+import gherkin.Parser;
+import gherkin.ParserException;
+import gherkin.TokenMatcher;
+import gherkin.ast.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ScenarioStorage {
+    private final Map<String, TestSourceRead> pathToScenarioMap = new HashMap<>();
+    private final Map<String, Map<Integer, CucumberNode>> pathToNodeMap = new HashMap<>();
+
+    public static ScenarioDefinition getScenarioDefinition(final CucumberNode cucumberNode) {
+        return cucumberNode.node instanceof ScenarioDefinition ? (ScenarioDefinition) cucumberNode.node
+                : (ScenarioDefinition) cucumberNode.parent.parent.node;
+    }
+
+    public void addScenarioEvent(final String path, final TestSourceRead event) {
+        pathToScenarioMap.put(path, event);
+    }
+
+    public CucumberNode getCucumberNode(final String path, final int line) {
+        if (!pathToNodeMap.containsKey(path)) {
+            parseGherkinSource(path);
+        }
+        if (pathToNodeMap.containsKey(path)) {
+            return pathToNodeMap.get(path).get(line);
+        }
+        return null;
+    }
+
+    private void parseGherkinSource(final String path) {
+        if (!pathToScenarioMap.containsKey(path)) {
+            return;
+        }
+        final Parser<GherkinDocument> parser = new Parser<>(new AstBuilder());
+        final TokenMatcher matcher = new TokenMatcher();
+        try {
+            final GherkinDocument gherkinDocument = parser.parse(pathToScenarioMap.get(path).source,
+                    matcher);
+            final Map<Integer, CucumberNode> nodeMap = new HashMap<>();
+            final CucumberNode currentParent = new CucumberNode(gherkinDocument.getFeature(), null);
+            for (ScenarioDefinition child : gherkinDocument.getFeature().getChildren()) {
+                processScenarioDefinition(nodeMap, child, currentParent);
+            }
+            pathToNodeMap.put(path, nodeMap);
+        } catch (ParserException e) {
+            throw new IllegalStateException("You are using a plugin that only supports till Gherkin 5.\n"
+                    + "Please check if the Gherkin provided follows the standard of Gherkin 5\n", e
+            );
+        }
+    }
+
+    private void processScenarioDefinition(final Map<Integer, CucumberNode> nodeMap, final ScenarioDefinition child,
+                                           final CucumberNode currentParent) {
+        final CucumberNode childNode = new CucumberNode(child, currentParent);
+        nodeMap.put(child.getLocation().getLine(), childNode);
+        for (Step step : child.getSteps()) {
+            nodeMap.put(step.getLocation().getLine(), createCucumberNode(step, childNode));
+        }
+        if (child instanceof ScenarioOutline) {
+            processScenarioOutlineExamples(nodeMap, (ScenarioOutline) child, childNode);
+        }
+    }
+
+    private void processScenarioOutlineExamples(final Map<Integer, CucumberNode> nodeMap,
+                                                final ScenarioOutline scenarioOutline,
+                                                final CucumberNode childNode) {
+        for (Examples examples : scenarioOutline.getExamples()) {
+            final CucumberNode examplesNode = createCucumberNode(examples, childNode);
+            final TableRow headerRow = examples.getTableHeader();
+            final CucumberNode headerNode = createCucumberNode(headerRow, examplesNode);
+            nodeMap.put(headerRow.getLocation().getLine(), headerNode);
+            for (int i = 0; i < examples.getTableBody().size(); ++i) {
+                final TableRow examplesRow = examples.getTableBody().get(i);
+                final Node rowNode = createExamplesRowWrapperNode(examplesRow, i);
+                final CucumberNode expandedScenarioNode = createCucumberNode(rowNode, examplesNode);
+                nodeMap.put(examplesRow.getLocation().getLine(), expandedScenarioNode);
+            }
+        }
+    }
+
+    private static ExamplesRowWrapperNode createExamplesRowWrapperNode(final Node examplesRow, final int bodyRowIndex) {
+        return new ExamplesRowWrapperNode(examplesRow, bodyRowIndex);
+    }
+
+    private static CucumberNode createCucumberNode(final Node node, final CucumberNode astNode) {
+        return new CucumberNode(node, astNode);
+    }
+
+    public static class ExamplesRowWrapperNode extends Node {
+        private final int bodyRowIndex;
+
+        public int getBodyRowIndex() {
+            return bodyRowIndex;
+        }
+
+        ExamplesRowWrapperNode(final Node examplesRow, final int bodyRowIndex) {
+            super(examplesRow.getLocation());
+            this.bodyRowIndex = bodyRowIndex;
+        }
+    }
+
+    public static class CucumberNode {
+        private final Node node;
+        private final CucumberNode parent;
+
+        CucumberNode(final Node node, final CucumberNode parent) {
+            this.node = node;
+            this.parent = parent;
+        }
+    }
+}

--- a/qase-cucumber-v4-reporter/pom.xml
+++ b/qase-cucumber-v4-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.3</version>
+        <version>4.1.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v4-reporter/src/main/java/io/qase/cucumber4/ScenarioStorage.java
+++ b/qase-cucumber-v4-reporter/src/main/java/io/qase/cucumber4/ScenarioStorage.java
@@ -1,0 +1,117 @@
+package io.qase.cucumber4;
+
+import cucumber.api.event.TestSourceRead;
+import gherkin.AstBuilder;
+import gherkin.Parser;
+import gherkin.ParserException;
+import gherkin.TokenMatcher;
+import gherkin.ast.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ScenarioStorage {
+    private final Map<String, TestSourceRead> pathToScenarioMap = new HashMap<>();
+    private final Map<String, Map<Integer, CucumberNode>> pathToNodeMap = new HashMap<>();
+
+    public static ScenarioDefinition getScenarioDefinition(final CucumberNode cucumberNode) {
+        return cucumberNode.node instanceof ScenarioDefinition ? (ScenarioDefinition) cucumberNode.node
+                : (ScenarioDefinition) cucumberNode.parent.parent.node;
+    }
+
+    public void addScenarioEvent(final String path, final TestSourceRead event) {
+        pathToScenarioMap.put(path, event);
+    }
+
+    public CucumberNode getCucumberNode(final String path, final int line) {
+        if (!pathToNodeMap.containsKey(path)) {
+            parseGherkinSource(path);
+        }
+        if (pathToNodeMap.containsKey(path)) {
+            return pathToNodeMap.get(path).get(line);
+        }
+        return null;
+    }
+
+    private void parseGherkinSource(final String path) {
+        if (!pathToScenarioMap.containsKey(path)) {
+            return;
+        }
+        final Parser<GherkinDocument> parser = new Parser<>(new AstBuilder());
+        final TokenMatcher matcher = new TokenMatcher();
+        try {
+            final GherkinDocument gherkinDocument = parser.parse(pathToScenarioMap.get(path).source,
+                    matcher);
+            final Map<Integer, CucumberNode> nodeMap = new HashMap<>();
+            final CucumberNode currentParent = new CucumberNode(gherkinDocument.getFeature(), null);
+            for (ScenarioDefinition child : gherkinDocument.getFeature().getChildren()) {
+                processScenarioDefinition(nodeMap, child, currentParent);
+            }
+            pathToNodeMap.put(path, nodeMap);
+        } catch (ParserException e) {
+            throw new IllegalStateException("You are using a plugin that only supports till Gherkin 5.\n"
+                    + "Please check if the Gherkin provided follows the standard of Gherkin 5\n", e
+            );
+        }
+    }
+
+    private void processScenarioDefinition(final Map<Integer, CucumberNode> nodeMap, final ScenarioDefinition child,
+                                           final CucumberNode currentParent) {
+        final CucumberNode childNode = new CucumberNode(child, currentParent);
+        nodeMap.put(child.getLocation().getLine(), childNode);
+        for (Step step : child.getSteps()) {
+            nodeMap.put(step.getLocation().getLine(), createCucumberNode(step, childNode));
+        }
+        if (child instanceof ScenarioOutline) {
+            processScenarioOutlineExamples(nodeMap, (ScenarioOutline) child, childNode);
+        }
+    }
+
+    private void processScenarioOutlineExamples(final Map<Integer, CucumberNode> nodeMap,
+                                                final ScenarioOutline scenarioOutline,
+                                                final CucumberNode childNode) {
+        for (Examples examples : scenarioOutline.getExamples()) {
+            final CucumberNode examplesNode = createCucumberNode(examples, childNode);
+            final TableRow headerRow = examples.getTableHeader();
+            final CucumberNode headerNode = createCucumberNode(headerRow, examplesNode);
+            nodeMap.put(headerRow.getLocation().getLine(), headerNode);
+            for (int i = 0; i < examples.getTableBody().size(); ++i) {
+                final TableRow examplesRow = examples.getTableBody().get(i);
+                final Node rowNode = createExamplesRowWrapperNode(examplesRow, i);
+                final CucumberNode expandedScenarioNode = createCucumberNode(rowNode, examplesNode);
+                nodeMap.put(examplesRow.getLocation().getLine(), expandedScenarioNode);
+            }
+        }
+    }
+
+    private static ExamplesRowWrapperNode createExamplesRowWrapperNode(final Node examplesRow, final int bodyRowIndex) {
+        return new ExamplesRowWrapperNode(examplesRow, bodyRowIndex);
+    }
+
+    private static CucumberNode createCucumberNode(final Node node, final CucumberNode astNode) {
+        return new CucumberNode(node, astNode);
+    }
+
+    public static class ExamplesRowWrapperNode extends Node {
+        private final int bodyRowIndex;
+
+        public int getBodyRowIndex() {
+            return bodyRowIndex;
+        }
+
+        ExamplesRowWrapperNode(final Node examplesRow, final int bodyRowIndex) {
+            super(examplesRow.getLocation());
+            this.bodyRowIndex = bodyRowIndex;
+        }
+    }
+
+    public static class CucumberNode {
+        private final Node node;
+        private final CucumberNode parent;
+
+        CucumberNode(final Node node, final CucumberNode parent) {
+            this.node = node;
+            this.parent = parent;
+        }
+    }
+}

--- a/qase-cucumber-v5-reporter/pom.xml
+++ b/qase-cucumber-v5-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.3</version>
+        <version>4.1.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -32,6 +32,11 @@
             <groupId>io.cucumber</groupId>
             <artifactId>cucumber-java</artifactId>
             <version>${cucumber5-java.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>gherkin</artifactId>
+            <version>5.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/qase-cucumber-v5-reporter/src/main/java/io/qase/cucumber5/ScenarioStorage.java
+++ b/qase-cucumber-v5-reporter/src/main/java/io/qase/cucumber5/ScenarioStorage.java
@@ -1,0 +1,118 @@
+package io.qase.cucumber5;
+
+import gherkin.AstBuilder;
+import gherkin.Parser;
+import gherkin.ParserException;
+import gherkin.TokenMatcher;
+import gherkin.ast.*;
+import io.cucumber.plugin.event.TestSourceRead;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ScenarioStorage {
+    private final Map<URI, TestSourceRead> pathToScenarioMap = new HashMap<>();
+    private final Map<URI, Map<Integer, CucumberNode>> pathToNodeMap = new HashMap<>();
+
+    public static ScenarioDefinition getScenarioDefinition(final CucumberNode cucumberNode) {
+        return cucumberNode.node instanceof ScenarioDefinition ? (ScenarioDefinition) cucumberNode.node
+                : (ScenarioDefinition) cucumberNode.parent.parent.node;
+    }
+
+    public void addScenarioEvent(final URI path, final TestSourceRead event) {
+        pathToScenarioMap.put(path, event);
+    }
+
+    public CucumberNode getCucumberNode(final URI path, final int line) {
+        if (!pathToNodeMap.containsKey(path)) {
+            parseGherkinSource(path);
+        }
+        if (pathToNodeMap.containsKey(path)) {
+            return pathToNodeMap.get(path).get(line);
+        }
+        return null;
+    }
+
+    private void parseGherkinSource(final URI path) {
+        if (!pathToScenarioMap.containsKey(path)) {
+            return;
+        }
+        final Parser<GherkinDocument> parser = new Parser<>(new AstBuilder());
+        final TokenMatcher matcher = new TokenMatcher();
+        try {
+            final GherkinDocument gherkinDocument = parser.parse(pathToScenarioMap.get(path).getSource(),
+                    matcher);
+            final Map<Integer, CucumberNode> nodeMap = new HashMap<>();
+            final CucumberNode currentParent = new CucumberNode(gherkinDocument.getFeature(), null);
+            for (ScenarioDefinition child : gherkinDocument.getFeature().getChildren()) {
+                processScenarioDefinition(nodeMap, child, currentParent);
+            }
+            pathToNodeMap.put(path, nodeMap);
+        } catch (ParserException e) {
+            throw new IllegalStateException("You are using a plugin that only supports till Gherkin 5.\n"
+                    + "Please check if the Gherkin provided follows the standard of Gherkin 5\n", e
+            );
+        }
+    }
+
+    private void processScenarioDefinition(final Map<Integer, CucumberNode> nodeMap, final ScenarioDefinition child,
+                                           final CucumberNode currentParent) {
+        final CucumberNode childNode = new CucumberNode(child, currentParent);
+        nodeMap.put(child.getLocation().getLine(), childNode);
+        for (Step step : child.getSteps()) {
+            nodeMap.put(step.getLocation().getLine(), createCucumberNode(step, childNode));
+        }
+        if (child instanceof ScenarioOutline) {
+            processScenarioOutlineExamples(nodeMap, (ScenarioOutline) child, childNode);
+        }
+    }
+
+    private void processScenarioOutlineExamples(final Map<Integer, CucumberNode> nodeMap,
+                                                final ScenarioOutline scenarioOutline,
+                                                final CucumberNode childNode) {
+        for (Examples examples : scenarioOutline.getExamples()) {
+            final CucumberNode examplesNode = createCucumberNode(examples, childNode);
+            final TableRow headerRow = examples.getTableHeader();
+            final CucumberNode headerNode = createCucumberNode(headerRow, examplesNode);
+            nodeMap.put(headerRow.getLocation().getLine(), headerNode);
+            for (int i = 0; i < examples.getTableBody().size(); ++i) {
+                final TableRow examplesRow = examples.getTableBody().get(i);
+                final Node rowNode = createExamplesRowWrapperNode(examplesRow, i);
+                final CucumberNode expandedScenarioNode = createCucumberNode(rowNode, examplesNode);
+                nodeMap.put(examplesRow.getLocation().getLine(), expandedScenarioNode);
+            }
+        }
+    }
+
+    private static ExamplesRowWrapperNode createExamplesRowWrapperNode(final Node examplesRow, final int bodyRowIndex) {
+        return new ExamplesRowWrapperNode(examplesRow, bodyRowIndex);
+    }
+
+    private static CucumberNode createCucumberNode(final Node node, final CucumberNode astNode) {
+        return new CucumberNode(node, astNode);
+    }
+
+    public static class ExamplesRowWrapperNode extends Node {
+        private final int bodyRowIndex;
+
+        public int getBodyRowIndex() {
+            return bodyRowIndex;
+        }
+
+        ExamplesRowWrapperNode(final Node examplesRow, final int bodyRowIndex) {
+            super(examplesRow.getLocation());
+            this.bodyRowIndex = bodyRowIndex;
+        }
+    }
+
+    public static class CucumberNode {
+        private final Node node;
+        private final CucumberNode parent;
+
+        CucumberNode(final Node node, final CucumberNode parent) {
+            this.node = node;
+            this.parent = parent;
+        }
+    }
+}

--- a/qase-cucumber-v6-reporter/pom.xml
+++ b/qase-cucumber-v6-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.3</version>
+        <version>4.1.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v6-reporter/src/main/java/io/qase/cucumber6/ScenarioStorage.java
+++ b/qase-cucumber-v6-reporter/src/main/java/io/qase/cucumber6/ScenarioStorage.java
@@ -1,0 +1,153 @@
+package io.qase.cucumber6;
+
+import io.cucumber.gherkin.Gherkin;
+import io.cucumber.messages.Messages;
+import io.cucumber.messages.Messages.GherkinDocument;
+import io.cucumber.messages.Messages.GherkinDocument.Feature.*;
+import io.cucumber.messages.Messages.GherkinDocument.Feature.FeatureChild.RuleChild;
+import io.cucumber.messages.Messages.GherkinDocument.Feature.Scenario.Examples;
+import io.cucumber.messages.internal.com.google.protobuf.GeneratedMessageV3;
+import io.cucumber.plugin.event.TestSourceRead;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static io.cucumber.gherkin.Gherkin.makeSourceEnvelope;
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
+
+public class ScenarioStorage {
+    private final Map<URI, TestSourceRead> pathToScenarioMap = new HashMap<>();
+    private final Map<URI, Map<Integer, CucumberNode>> pathToNodeMap = new HashMap<>();
+
+    public static Scenario getScenarioDefinition(final CucumberNode cucumberNode) {
+        CucumberNode candidate = cucumberNode;
+        while (candidate != null && !(candidate.node instanceof Scenario)) {
+            candidate = candidate.parent;
+        }
+        return candidate == null ? null : (Scenario) candidate.node;
+    }
+
+    public void addScenarioEvent(final URI path, final TestSourceRead event) {
+        pathToScenarioMap.put(path, event);
+    }
+
+    public CucumberNode getCucumberNode(final URI path, final int line) {
+        if (!pathToNodeMap.containsKey(path)) {
+            parseGherkinSource(path);
+        }
+        if (pathToNodeMap.containsKey(path)) {
+            return pathToNodeMap.get(path).get(line);
+        }
+        return null;
+    }
+
+    private void parseGherkinSource(final URI path) {
+        if (!pathToScenarioMap.containsKey(path)) {
+            return;
+        }
+        final String source = pathToScenarioMap.get(path).getSource();
+
+        final List<Messages.Envelope> sources = singletonList(
+                makeSourceEnvelope(source, path.toString()));
+
+        final List<Messages.Envelope> envelopes = Gherkin.fromSources(
+                sources,
+                true,
+                true,
+                true,
+                () -> String.valueOf(UUID.randomUUID())).collect(toList());
+
+        final GherkinDocument gherkinDocument = envelopes.stream()
+                .filter(Messages.Envelope::hasGherkinDocument)
+                .map(Messages.Envelope::getGherkinDocument)
+                .findFirst()
+                .orElse(null);
+
+        final Map<Integer, CucumberNode> nodeMap = new HashMap<>();
+        final CucumberNode currentParent = createCucumberNode(gherkinDocument.getFeature(), null);
+        for (FeatureChild child : gherkinDocument.getFeature().getChildrenList()) {
+            processFeatureDefinition(nodeMap, child, currentParent);
+        }
+        pathToNodeMap.put(path, nodeMap);
+    }
+
+    private void processFeatureDefinition(
+            final Map<Integer, CucumberNode> nodeMap, final FeatureChild child, final CucumberNode currentParent) {
+        if (child.hasBackground()) {
+            processBackgroundDefinition(nodeMap, child.getBackground(), currentParent);
+        } else if (child.hasScenario()) {
+            processScenarioDefinition(nodeMap, child.getScenario(), currentParent);
+        } else if (child.hasRule()) {
+            final CucumberNode childNode = createCucumberNode(child.getRule(), currentParent);
+            nodeMap.put(child.getRule().getLocation().getLine(), childNode);
+            for (RuleChild ruleChild : child.getRule().getChildrenList()) {
+                processRuleDefinition(nodeMap, ruleChild, childNode);
+            }
+        }
+    }
+
+    private void processScenarioDefinition(final Map<Integer, CucumberNode> nodeMap, final Scenario child,
+                                           final CucumberNode currentParent) {
+        final CucumberNode childNode = createCucumberNode(child, currentParent);
+        nodeMap.put(child.getLocation().getLine(), childNode);
+        for (Step step : child.getStepsList()) {
+            nodeMap.put(step.getLocation().getLine(), createCucumberNode(step, childNode));
+        }
+        if (child.getExamplesCount() > 0) {
+            processScenarioOutlineExamples(nodeMap, child, childNode);
+        }
+    }
+
+    private void processBackgroundDefinition(
+            final Map<Integer, CucumberNode> nodeMap, final Background background, final CucumberNode currentParent
+    ) {
+        final CucumberNode childNode = createCucumberNode(background, currentParent);
+        nodeMap.put(background.getLocation().getLine(), childNode);
+        for (Step step : background.getStepsList()) {
+            nodeMap.put(step.getLocation().getLine(), createCucumberNode(step, childNode));
+        }
+    }
+
+    private void processRuleDefinition(
+            final Map<Integer, CucumberNode> nodeMap, final RuleChild child, final CucumberNode currentParent) {
+        if (child.hasBackground()) {
+            processBackgroundDefinition(nodeMap, child.getBackground(), currentParent);
+        } else if (child.hasScenario()) {
+            processScenarioDefinition(nodeMap, child.getScenario(), currentParent);
+        }
+    }
+
+    private void processScenarioOutlineExamples(final Map<Integer, CucumberNode> nodeMap,
+                                                final Scenario scenarioOutline,
+                                                final CucumberNode parent) {
+        for (Examples examples : scenarioOutline.getExamplesList()) {
+            final CucumberNode examplesNode = createCucumberNode(examples, parent);
+            final TableRow headerRow = examples.getTableHeader();
+            final CucumberNode headerNode = createCucumberNode(headerRow, examplesNode);
+            nodeMap.put(headerRow.getLocation().getLine(), headerNode);
+            for (int i = 0; i < examples.getTableBodyCount(); ++i) {
+                final TableRow examplesRow = examples.getTableBody(i);
+                final CucumberNode expandedScenarioNode = createCucumberNode(examplesRow, examplesNode);
+                nodeMap.put(examplesRow.getLocation().getLine(), expandedScenarioNode);
+            }
+        }
+    }
+
+    private static CucumberNode createCucumberNode(final GeneratedMessageV3 node, final CucumberNode astNode) {
+        return new CucumberNode(node, astNode);
+    }
+
+    public static class CucumberNode {
+        private final GeneratedMessageV3 node;
+        private final CucumberNode parent;
+
+        CucumberNode(final GeneratedMessageV3 node, final CucumberNode parent) {
+            this.node = node;
+            this.parent = parent;
+        }
+    }
+}

--- a/qase-cucumber-v7-reporter/pom.xml
+++ b/qase-cucumber-v7-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.3</version>
+        <version>4.1.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v7-reporter/src/main/java/io/qase/cucumber7/QaseEventListener.java
+++ b/qase-cucumber-v7-reporter/src/main/java/io/qase/cucumber7/QaseEventListener.java
@@ -1,6 +1,15 @@
 package io.qase.cucumber7;
 
+import io.cucumber.messages.types.*;
+import io.cucumber.messages.types.Step;
 import io.cucumber.plugin.event.*;
+import io.cucumber.plugin.event.TestCase;
+import io.cucumber.plugin.event.TestCaseFinished;
+import io.cucumber.plugin.event.TestCaseStarted;
+import io.cucumber.plugin.event.TestRunFinished;
+import io.cucumber.plugin.event.TestRunStarted;
+import io.cucumber.plugin.event.TestStepFinished;
+import io.cucumber.plugin.event.TestStepStarted;
 import io.qase.commons.CasesStorage;
 import io.qase.commons.StepStorage;
 import io.qase.commons.utils.CucumberUtils;
@@ -9,29 +18,38 @@ import io.qase.commons.reporters.CoreReporterFactory;
 import io.cucumber.plugin.ConcurrentEventListener;
 import io.qase.commons.reporters.Reporter;
 
+import java.net.URI;
 import java.time.Instant;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
+import java.util.stream.IntStream;
 
 import static io.qase.commons.utils.IntegrationUtils.getStacktrace;
 
 public class QaseEventListener implements ConcurrentEventListener {
 
     private final Reporter qaseTestCaseListener;
+    private final ScenarioStorage scenarioStorage;
+
+    private final ThreadLocal<URI> currentFeatureFile = new InheritableThreadLocal<>();
 
     public QaseEventListener() {
         this.qaseTestCaseListener = CoreReporterFactory.getInstance();
+        this.scenarioStorage = new ScenarioStorage();
     }
 
     @Override
     public void setEventPublisher(EventPublisher publisher) {
+        publisher.registerHandlerFor(TestSourceRead.class, this::scenarioRead);
         publisher.registerHandlerFor(TestCaseStarted.class, this::testCaseStarted);
         publisher.registerHandlerFor(TestCaseFinished.class, this::testCaseFinished);
         publisher.registerHandlerFor(TestRunStarted.class, this::testRunStarted);
         publisher.registerHandlerFor(TestRunFinished.class, this::testRunFinished);
         publisher.registerHandlerFor(TestStepStarted.class, this::testStepStarted);
         publisher.registerHandlerFor(TestStepFinished.class, this::testStepFinished);
+    }
+
+    private void scenarioRead(TestSourceRead event) {
+        this.scenarioStorage.addScenarioEvent(event.getUri(), event);
     }
 
     private void testRunStarted(TestRunStarted testRunStarted) {
@@ -54,8 +72,16 @@ public class QaseEventListener implements ConcurrentEventListener {
         if (testStepFinished.getTestStep() instanceof PickleStepTestStep) {
             PickleStepTestStep step = (PickleStepTestStep) testStepFinished.getTestStep();
             StepResult stepResult = StepStorage.getCurrentStep();
+
             stepResult.data.action = step.getStep().getText();
             stepResult.execution.status = this.convertStepStatus(testStepFinished.getResult().getStatus());
+
+            Step cucumberStep = getCucumberStep(currentFeatureFile.get(), step.getStep().getLine());
+
+            if (cucumberStep != null && cucumberStep.getDataTable().isPresent() && !cucumberStep.getDataTable().get().getRows().isEmpty()) {
+                stepResult.data.inputData = CucumberUtils.formatTable(convertTableRowsToLists(cucumberStep.getDataTable().get().getRows()));
+            }
+
             StepStorage.stopStep();
         }
     }
@@ -83,6 +109,17 @@ public class QaseEventListener implements ConcurrentEventListener {
         if (ignore) {
             resultCreate.ignore = true;
             return resultCreate;
+        }
+
+        currentFeatureFile.set(event.getTestCase().getUri());
+
+        final Scenario scenarioDefinition = ScenarioStorage.getScenarioDefinition(scenarioStorage.getCucumberNode(currentFeatureFile.get(), event.getTestCase().getLocation().getLine()));
+
+        Map<String, String> parameters = new HashMap<>();
+
+        if (scenarioDefinition.getExamples() != null) {
+            parameters =
+                    getExamplesAsParameters(scenarioDefinition, event.getTestCase());
         }
 
         List<Long> caseIds = CucumberUtils.getCaseIds(tags);
@@ -113,6 +150,7 @@ public class QaseEventListener implements ConcurrentEventListener {
         resultCreate.execution.thread = Thread.currentThread().getName();
         resultCreate.fields = fields;
         resultCreate.relations = relations;
+        resultCreate.params = parameters;
 
         return resultCreate;
     }
@@ -170,5 +208,68 @@ public class QaseEventListener implements ConcurrentEventListener {
             default:
                 return StepResultStatus.BLOCKED;
         }
+    }
+
+    private Map<String, String> getExamplesAsParameters(
+            final Scenario scenario, final TestCase localCurrentTestCase
+    ) {
+        final Optional<Examples> maybeExample =
+                scenario.getExamples().stream()
+                        .filter(example -> example.getTableBody().stream()
+                                .anyMatch(row -> row.getLocation().getLine()
+                                        == localCurrentTestCase.getLocation().getLine())
+                        )
+                        .findFirst();
+
+        if (!maybeExample.isPresent()) {
+            return Collections.emptyMap();
+        }
+
+        final Examples examples = maybeExample.get();
+
+        final Optional<TableRow> maybeRow = examples.getTableBody().stream()
+                .filter(example -> example.getLocation().getLine() == localCurrentTestCase.getLocation().getLine())
+                .findFirst();
+
+        if (!maybeRow.isPresent()) {
+            return Collections.emptyMap();
+        }
+
+        final TableRow row = maybeRow.get();
+        final Map<String, String> parameters = new HashMap<>();
+
+        IntStream.range(0, examples.getTableHeader().get().getCells().size()).forEach
+                (index -> {
+                    final String name = examples.getTableHeader().get().getCells().get(index).getValue();
+                    final String value = row.getCells().get(index).getValue();
+                    parameters.put(name, value);
+                });
+
+        return parameters;
+    }
+
+
+    private Step getCucumberStep(final URI uri, final int stepLine) {
+        Scenario scenario = ScenarioStorage.getScenarioDefinition(scenarioStorage.getCucumberNode(uri, stepLine));
+
+        if (scenario == null) {
+            return null;
+        }
+
+        return scenario.getSteps().stream().filter(s -> s.getLocation().getLine().equals((long) stepLine)).findFirst().orElse(null);
+    }
+
+    private List<List<String>> convertTableRowsToLists(List<TableRow> rows) {
+        List<List<String>> result = new ArrayList<>();
+
+        for (TableRow row : rows) {
+            List<String> rowValues = new ArrayList<>();
+            for (TableCell cell : row.getCells()) {
+                rowValues.add(cell.getValue());
+            }
+            result.add(rowValues);
+        }
+
+        return result;
     }
 }

--- a/qase-cucumber-v7-reporter/src/main/java/io/qase/cucumber7/ScenarioStorage.java
+++ b/qase-cucumber-v7-reporter/src/main/java/io/qase/cucumber7/ScenarioStorage.java
@@ -1,0 +1,135 @@
+package io.qase.cucumber7;
+
+import io.cucumber.gherkin.GherkinParser;
+import io.cucumber.messages.types.*;
+import io.cucumber.plugin.event.TestSourceRead;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+public class ScenarioStorage {
+    private final Map<URI, TestSourceRead> pathToScenarioMap = new HashMap<>();
+    private final Map<URI, Map<Long, CucumberNode>> pathToNodeMap = new HashMap<>();
+
+    public static Scenario getScenarioDefinition(final CucumberNode cucumberNode) {
+        CucumberNode candidate = cucumberNode;
+        while (candidate != null && !(candidate.node instanceof Scenario)) {
+            candidate = candidate.parent;
+        }
+        return candidate == null ? null : (Scenario) candidate.node;
+    }
+
+    public void addScenarioEvent(final URI path, final TestSourceRead event) {
+        pathToScenarioMap.put(path, event);
+    }
+
+    public CucumberNode getCucumberNode(final URI path, final int line) {
+        if (!pathToNodeMap.containsKey(path)) {
+            parseGherkinSource(path);
+        }
+        if (pathToNodeMap.containsKey(path)) {
+            return pathToNodeMap.get(path).get((long) line);
+        }
+        return null;
+    }
+
+    private void parseGherkinSource(final URI path) {
+        if (!pathToScenarioMap.containsKey(path)) {
+            return;
+        }
+        final String source = pathToScenarioMap.get(path).getSource();
+
+        final GherkinParser parser = GherkinParser.builder()
+                .build();
+
+        final Stream<Envelope> envelopes = parser.parse(
+                Envelope.of(new Source(path.toString(), source, SourceMediaType.TEXT_X_CUCUMBER_GHERKIN_PLAIN)));
+
+        final GherkinDocument gherkinDocument = envelopes
+                .map(Envelope::getGherkinDocument)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .findFirst()
+                .orElse(null);
+
+        final Map<Long, CucumberNode> nodeMap = new HashMap<>();
+        final Feature feature = gherkinDocument.getFeature().get();
+        final CucumberNode currentParent = createCucumberNode(feature, null);
+        for (FeatureChild child : feature.getChildren()) {
+            processFeatureDefinition(nodeMap, child, currentParent);
+        }
+        pathToNodeMap.put(path, nodeMap);
+    }
+
+    private void processFeatureDefinition(
+            final Map<Long, CucumberNode> nodeMap, final FeatureChild child, final CucumberNode currentParent) {
+        child.getBackground().ifPresent(background -> processBackgroundDefinition(nodeMap, background, currentParent));
+        child.getScenario().ifPresent(scenario -> processScenarioDefinition(nodeMap, scenario, currentParent));
+        child.getRule().ifPresent(rule -> {
+            final CucumberNode childNode = new CucumberNode(rule, currentParent);
+            nodeMap.put(rule.getLocation().getLine(), childNode);
+            rule.getChildren().forEach(ruleChild -> processRuleDefinition(nodeMap, ruleChild, childNode));
+        });
+    }
+
+    private void processScenarioDefinition(final Map<Long, CucumberNode> nodeMap, final Scenario child,
+                                           final CucumberNode currentParent) {
+        final CucumberNode childNode = createCucumberNode(child, currentParent);
+        nodeMap.put(child.getLocation().getLine(), childNode);
+        for (Step step : child.getSteps()) {
+            nodeMap.put(step.getLocation().getLine(), createCucumberNode(step, childNode));
+        }
+        if (!child.getExamples().isEmpty()) {
+            processScenarioOutlineExamples(nodeMap, child, childNode);
+        }
+    }
+
+    private void processBackgroundDefinition(
+            final Map<Long, CucumberNode> nodeMap, final Background background, final CucumberNode currentParent
+    ) {
+        final CucumberNode childNode = createCucumberNode(background, currentParent);
+        nodeMap.put(background.getLocation().getLine(), childNode);
+        for (Step step : background.getSteps()) {
+            nodeMap.put(step.getLocation().getLine(), createCucumberNode(step, childNode));
+        }
+    }
+
+    private void processRuleDefinition(
+            final Map<Long, CucumberNode> nodeMap, final RuleChild child, final CucumberNode currentParent) {
+        child.getBackground().ifPresent(background -> processBackgroundDefinition(nodeMap, background, currentParent));
+        child.getScenario().ifPresent(scenario -> processScenarioDefinition(nodeMap, scenario, currentParent));
+    }
+
+    private void processScenarioOutlineExamples(final Map<Long, CucumberNode> nodeMap,
+                                                final Scenario scenarioOutline,
+                                                final CucumberNode parent) {
+        for (Examples examples : scenarioOutline.getExamples()) {
+            final CucumberNode examplesNode = createCucumberNode(examples, parent);
+            final TableRow headerRow = examples.getTableHeader().get();
+            final CucumberNode headerNode = createCucumberNode(headerRow, examplesNode);
+            nodeMap.put(headerRow.getLocation().getLine(), headerNode);
+            for (int i = 0; i < examples.getTableBody().size(); ++i) {
+                final TableRow examplesRow = examples.getTableBody().get(i);
+                final CucumberNode expandedScenarioNode = createCucumberNode(examplesRow, examplesNode);
+                nodeMap.put(examplesRow.getLocation().getLine(), expandedScenarioNode);
+            }
+        }
+    }
+
+    private static CucumberNode createCucumberNode(final Object node, final CucumberNode astNode) {
+        return new CucumberNode(node, astNode);
+    }
+
+    public static class CucumberNode {
+        private final Object node;
+        private final CucumberNode parent;
+
+        CucumberNode(final Object node, final CucumberNode parent) {
+            this.node = node;
+            this.parent = parent;
+        }
+    }
+}

--- a/qase-java-commons/pom.xml
+++ b/qase-java-commons/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.qase</groupId>
         <artifactId>qase-java</artifactId>
-        <version>4.1.3</version>
+        <version>4.1.4</version>
     </parent>
 
     <artifactId>qase-java-commons</artifactId>

--- a/qase-java-commons/src/main/java/io/qase/commons/client/ApiClientV2.java
+++ b/qase-java-commons/src/main/java/io/qase/commons/client/ApiClientV2.java
@@ -160,6 +160,10 @@ public class ApiClientV2 implements ApiClient {
         ResultStepData data = new ResultStepData()
                 .action(step.data.action);
 
+        if (step.data.inputData != null) {
+            data.inputData(step.data.inputData);
+        }
+
         List<String> attachments = step.attachments.stream()
                 .map(this.apiClientV1::uploadAttachment)
                 .filter(attachment -> !attachment.isEmpty())

--- a/qase-java-commons/src/main/java/io/qase/commons/utils/CucumberUtils.java
+++ b/qase-java-commons/src/main/java/io/qase/commons/utils/CucumberUtils.java
@@ -89,5 +89,41 @@ public final class CucumberUtils {
     public static int getHash(URI uri, Long line) {
         return (uri.toString() + line).hashCode();
     }
+
+    public static  String formatTable(List<List<String>> tableData) {
+        if (tableData == null || tableData.isEmpty()) {
+            return "";
+        }
+
+        StringBuilder result = new StringBuilder();
+
+        int[] maxWidths = new int[tableData.get(0).size()];
+
+        for (List<String> row : tableData) {
+            for (int i = 0; i < row.size(); i++) {
+                int cellLength = row.get(i).length();
+                if (cellLength > maxWidths[i]) {
+                    maxWidths[i] = cellLength;
+                }
+            }
+        }
+
+        for (List<String> row : tableData) {
+            result.append("| ");
+            for (int i = 0; i < row.size(); i++) {
+                String cellValue = row.get(i);
+                result.append(cellValue);
+
+                int padding = maxWidths[i] - cellValue.length() + 1;
+                for (int j = 0; j < padding; j++) {
+                    result.append(" ");
+                }
+                result.append("| ");
+            }
+            result.append("\n");
+        }
+
+        return result.toString().trim();
+    }
 }
 

--- a/qase-junit4-reporter/pom.xml
+++ b/qase-junit4-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.3</version>
+        <version>4.1.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-junit5-reporter/pom.xml
+++ b/qase-junit5-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.3</version>
+        <version>4.1.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-testng-reporter/pom.xml
+++ b/qase-testng-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.3</version>
+        <version>4.1.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
This pull request introduces version `4.1.4` of `qase-java`, adding support for step parameters and table arguments in Cucumber reporters, along with updates to example projects and dependency versions. The changes enhance test reporting capabilities and improve compatibility with parameterized tests.

### Key Changes:

#### New Features in Cucumber Reporters:
* Added support for step parameters and table arguments in Cucumber reporters to capture and display step definitions with arguments and tabular data in test results. [[1]](diffhunk://#diff-3bd14d078188074c410028847113ceae68865d0ad5b844a27183ef87fbe2fcc3R1-R14) [[2]](diffhunk://#diff-b35de0b4d32354ced403864d38dc90f14618da6b97b0d4bbb0271a9df4c51371R108-R116)

#### Updates to Example Projects:
* Introduced new step definitions and parameterized test scenarios in the following example projects:
  - `cucumber7-gradle-junit4` [[1]](diffhunk://#diff-bfae70973fa945d62a4b4717cf42edf897f0e0ee6c64655657ad5148594d3f41R3-R4) [[2]](diffhunk://#diff-bfae70973fa945d62a4b4717cf42edf897f0e0ee6c64655657ad5148594d3f41R35-R49) [[3]](diffhunk://#diff-15f85847f63f5f0bb0c496936b7016ba3fb0f247fbc36392c793cfc5f81733a0R1-R15)
  - `cucumber7-gradle-junit5` [[1]](diffhunk://#diff-c4c3df5f1e439f231138ea8d58427bf3806b2cb7ad4b37de478079c7040584dcR3-R4) [[2]](diffhunk://#diff-c4c3df5f1e439f231138ea8d58427bf3806b2cb7ad4b37de478079c7040584dcR35-R49) [[3]](diffhunk://#diff-15f85847f63f5f0bb0c496936b7016ba3fb0f247fbc36392c793cfc5f81733a0R1-R15)
  - `cucumber7-gradle-testng` [[1]](diffhunk://#diff-cd82a2618a9bb1647ff20dd3d9abf2e214d7456c9a05a4f547ba51c3a40e7d87R3-R4) [[2]](diffhunk://#diff-cd82a2618a9bb1647ff20dd3d9abf2e214d7456c9a05a4f547ba51c3a40e7d87R35-R49) [[3]](diffhunk://#diff-15f85847f63f5f0bb0c496936b7016ba3fb0f247fbc36392c793cfc5f81733a0R1-R15)
  - `cucumber7-maven-junit4` [[1]](diffhunk://#diff-bfae70973fa945d62a4b4717cf42edf897f0e0ee6c64655657ad5148594d3f41R3-R4) [[2]](diffhunk://#diff-bfae70973fa945d62a4b4717cf42edf897f0e0ee6c64655657ad5148594d3f41R35-R49) [[3]](diffhunk://#diff-15f85847f63f5f0bb0c496936b7016ba3fb0f247fbc36392c793cfc5f81733a0R1-R15)
  - `cucumber7-maven-junit5` [[1]](diffhunk://#diff-c4c3df5f1e439f231138ea8d58427bf3806b2cb7ad4b37de478079c7040584dcR3-R4) [[2]](diffhunk://#diff-c4c3df5f1e439f231138ea8d58427bf3806b2cb7ad4b37de478079c7040584dcR35-R49) [[3]](diffhunk://#diff-15f85847f63f5f0bb0c496936b7016ba3fb0f247fbc36392c793cfc5f81733a0R1-R15)
  - `cucumber7-maven-testng` [[1]](diffhunk://#diff-cd82a2618a9bb1647ff20dd3d9abf2e214d7456c9a05a4f547ba51c3a40e7d87R3-R4) [[2]](diffhunk://#diff-cd82a2618a9bb1647ff20dd3d9abf2e214d7456c9a05a4f547ba51c3a40e7d87R35-R49) [[3]](diffhunk://#diff-15f85847f63f5f0bb0c496936b7016ba3fb0f247fbc36392c793cfc5f81733a0R1-R15)

#### Dependency Version Updates:
* Updated the version of `qase-java` and its submodules to `4.1.4` in `pom.xml` files across the project. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L10-R10) [[2]](diffhunk://#diff-514718fdfdacca86f2493ed9c6b28cc51a1345d76c874502fac7f18fb2281ac3L8-R8) [[3]](diffhunk://#diff-b2f841fbc79604c93661caea3c4160164f6067df2d25120c4525a3cadb4298d4L9-R9) [[4]](diffhunk://#diff-52c515b32b1f02b9f152f58e3e0e18a219cb44a72102b327c800d746db5fc8dcL8-R8)

#### Enhancements to Cucumber Reporter (`qase-cucumber-v3-reporter`):
* Added new imports and implemented logic for handling scenario outlines and examples in the `QaseEventListener` class to support parameterized tests. [[1]](diffhunk://#diff-b35de0b4d32354ced403864d38dc90f14618da6b97b0d4bbb0271a9df4c51371R5-R11) [[2]](diffhunk://#diff-b35de0b4d32354ced403864d38dc90f14618da6b97b0d4bbb0271a9df4c51371L17-R50) [[3]](diffhunk://#diff-b35de0b4d32354ced403864d38dc90f14618da6b97b0d4bbb0271a9df4c51371R108-R116)

#### Documentation Update:
* Updated the `changelog.md` to reflect the new feature additions and version upgrade.