### PR TITLE
feat(cucumber): add support for BDD keywords in steps

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,6 +27,7 @@ jobs:
     if: startsWith(github.event.ref, 'refs/tags/')
     steps:
       - uses: actions/checkout@v4
+
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
@@ -39,9 +40,17 @@ jobs:
           server-password: OSSRH_CENTRAL_TOKEN
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: OSSRH_GPG_PASSPHRASE
+
       - name: Publish to Apache Maven Central
         run: mvn clean deploy -P release
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_CENTRAL_TOKEN: ${{ secrets.OSSRH_PASSWORD }}
           OSSRH_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+# qase-java 4.1.5
+
+## What's new
+
+Added support for BDD keywords (Given, When, Then, And, ect.) in Cucumber reporters for better step representation.
+
 # qase-java 4.1.4
 
 ## What's new

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.qase</groupId>
     <artifactId>qase-java</artifactId>
     <packaging>pom</packaging>
-    <version>4.1.4</version>
+    <version>4.1.5</version>
     <modules>
         <module>qase-java-commons</module>
         <module>qase-api-client</module>

--- a/qase-api-client/pom.xml
+++ b/qase-api-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.4</version>
+        <version>4.1.5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-api-v2-client/pom.xml
+++ b/qase-api-v2-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.qase</groupId>
         <artifactId>qase-java</artifactId>
-        <version>4.1.4</version>
+        <version>4.1.5</version>
     </parent>
 
     <artifactId>qase-api-v2-client</artifactId>

--- a/qase-cucumber-v3-reporter/pom.xml
+++ b/qase-cucumber-v3-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.4</version>
+        <version>4.1.5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v4-reporter/pom.xml
+++ b/qase-cucumber-v4-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.4</version>
+        <version>4.1.5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v5-reporter/pom.xml
+++ b/qase-cucumber-v5-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.4</version>
+        <version>4.1.5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v5-reporter/src/main/java/io/qase/cucumber5/QaseEventListener.java
+++ b/qase-cucumber-v5-reporter/src/main/java/io/qase/cucumber5/QaseEventListener.java
@@ -61,7 +61,7 @@ public class QaseEventListener implements ConcurrentEventListener {
         if (testStepFinished.getTestStep() instanceof PickleStepTestStep) {
             PickleStepTestStep step = (PickleStepTestStep) testStepFinished.getTestStep();
             StepResult stepResult = StepStorage.getCurrentStep();
-            stepResult.data.action = step.getStep().getText();
+            stepResult.data.action = step.getStep().getKeyWord() + " " + step.getStep().getText();
             stepResult.execution.status = this.convertStepStatus(testStepFinished.getResult().getStatus());
             StepStorage.stopStep();
         }

--- a/qase-cucumber-v6-reporter/pom.xml
+++ b/qase-cucumber-v6-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.4</version>
+        <version>4.1.5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v6-reporter/src/main/java/io/qase/cucumber6/QaseEventListener.java
+++ b/qase-cucumber-v6-reporter/src/main/java/io/qase/cucumber6/QaseEventListener.java
@@ -69,7 +69,7 @@ public class QaseEventListener implements ConcurrentEventListener {
             PickleStepTestStep step = (PickleStepTestStep) testStepFinished.getTestStep();
             StepResult stepResult = StepStorage.getCurrentStep();
 
-            stepResult.data.action = step.getStep().getText();
+            stepResult.data.action = step.getStep().getKeyword() + " " + step.getStep().getText();
             stepResult.execution.status = this.convertStepStatus(testStepFinished.getResult().getStatus());
 
             Step cucumberStep = getCucumberStep(currentFeatureFile.get(), step.getStep().getLine());

--- a/qase-cucumber-v7-reporter/pom.xml
+++ b/qase-cucumber-v7-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.4</version>
+        <version>4.1.5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v7-reporter/src/main/java/io/qase/cucumber7/QaseEventListener.java
+++ b/qase-cucumber-v7-reporter/src/main/java/io/qase/cucumber7/QaseEventListener.java
@@ -73,7 +73,7 @@ public class QaseEventListener implements ConcurrentEventListener {
             PickleStepTestStep step = (PickleStepTestStep) testStepFinished.getTestStep();
             StepResult stepResult = StepStorage.getCurrentStep();
 
-            stepResult.data.action = step.getStep().getText();
+            stepResult.data.action = step.getStep().getKeyword() + " " + step.getStep().getText();
             stepResult.execution.status = this.convertStepStatus(testStepFinished.getResult().getStatus());
 
             Step cucumberStep = getCucumberStep(currentFeatureFile.get(), step.getStep().getLine());

--- a/qase-java-commons/pom.xml
+++ b/qase-java-commons/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.qase</groupId>
         <artifactId>qase-java</artifactId>
-        <version>4.1.4</version>
+        <version>4.1.5</version>
     </parent>
 
     <artifactId>qase-java-commons</artifactId>

--- a/qase-junit4-reporter/pom.xml
+++ b/qase-junit4-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.4</version>
+        <version>4.1.5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-junit5-reporter/pom.xml
+++ b/qase-junit5-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.4</version>
+        <version>4.1.5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-testng-reporter/pom.xml
+++ b/qase-testng-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.4</version>
+        <version>4.1.5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
This pull request introduces version `4.1.5` of the `qase-java` library, which includes support for BDD keywords in Cucumber reporters, updates to the build workflow, and version bumps across multiple modules. Below is a breakdown of the most important changes:

### New Feature: BDD Keywords in Cucumber Reporters
* Enhanced Cucumber reporters (`v5`, `v6`, `v7`) to include BDD keywords (e.g., `Given`, `When`, `Then`) in step representations. This improves the clarity and accuracy of test step descriptions. (`qase-cucumber-v5-reporter/src/main/java/io/qase/cucumber5/QaseEventListener.java`, `qase-cucumber-v6-reporter/src/main/java/io/qase/cucumber6/QaseEventListener.java`, `qase-cucumber-v7-reporter/src/main/java/io/qase/cucumber7/QaseEventListener.java`) [[1]](diffhunk://#diff-77be9305e192abac93ea7d9d46ffd0a022e0e024d8acec88c5d3e8462a745d35L64-R64) [[2]](diffhunk://#diff-4a994f83ac775195e3c9750d52cc3b6f89582537ce359b2da65247c8baea73a3L72-R72) [[3]](diffhunk://#diff-00e1926b51da7fdba7868c958b8b087281da8c9349792ebe970159c322451e7cL76-R76)

### Build and Release Workflow Enhancements
* Updated `.github/workflows/build.yaml` to include steps for publishing to Apache Maven Central and creating GitHub releases with autogenerated release notes. (`.github/workflows/build.yaml`) [[1]](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1R30) [[2]](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1R43-R56)

### Version Updates
* Bumped the version of `qase-java` and all its submodules (e.g., `qase-api-client`, `qase-cucumber-v3-reporter`, `qase-junit5-reporter`) from `4.1.4` to `4.1.5`. (`pom.xml`, `qase-api-client/pom.xml`, `qase-cucumber-v3-reporter/pom.xml`, etc.) [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L10-R10) [[2]](diffhunk://#diff-514718fdfdacca86f2493ed9c6b28cc51a1345d76c874502fac7f18fb2281ac3L8-R8) [[3]](diffhunk://#diff-b2f841fbc79604c93661caea3c4160164f6067df2d25120c4525a3cadb4298d4L9-R9) [[4]](diffhunk://#diff-52c515b32b1f02b9f152f58e3e0e18a219cb44a72102b327c800d746db5fc8dcL8-R8) [[5]](diffhunk://#diff-86b8d7f9216c05d31872fdbe761c485f366052ebe73550b87426703a2aa75641L8-R8) [[6]](diffhunk://#diff-2a13ac9cd6493cd0ee2b5f04cbdf7468938e3b1e7265bac614812a75ba4ee713L8-R8) [[7]](diffhunk://#diff-8dca3b4b2c0f85527d8bbf623069a53ae88d17ff67f00c67b71a1806199886adL8-R8) [[8]](diffhunk://#diff-b14d9176febd68d8f2592505f4cad251e87e159ae3b1d07778ffea38abcc0ec9L8-R8) [[9]](diffhunk://#diff-fd60886a06671d6036def9287c94fe81b41d8febdd96e19da87d65aefbf36bdaL9-R9) [[10]](diffhunk://#diff-79a1b271637ed57e83005174230b63752c7e9165c49d2d19daae2a57c8d85bc7L8-R8) [[11]](diffhunk://#diff-c37a1a3bee150a3b54679b00ff4e69fbfa400fba50dc3d14a9c7a15571ca0039L8-R8) [[12]](diffhunk://#diff-2d7da0f3d513459b39793e52a7e3ffb2d05af6c1f851b303fe68ef7815db7814L8-R8)

### Documentation
* Added a changelog entry for version `4.1.5`, highlighting the new BDD keyword support in Cucumber reporters. (`changelog.md`)