### PR TITLE
fix: handle invalid JSON for TestCaseParams with anyOf schemas

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+# qase-java 4.1.6
+
+## What's new
+
+Fixed a JSON parsing error (java.io.IOException) in qase-api-client when handling TestCaseParams with anyOf schemas.
+
 # qase-java 4.1.5
 
 ## What's new

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.qase</groupId>
     <artifactId>qase-java</artifactId>
     <packaging>pom</packaging>
-    <version>4.1.5</version>
+    <version>4.1.6</version>
     <modules>
         <module>qase-java-commons</module>
         <module>qase-api-client</module>

--- a/qase-api-client/pom.xml
+++ b/qase-api-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.5</version>
+        <version>4.1.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-api-client/src/main/java/io/qase/client/v1/models/TestCaseParams.java
+++ b/qase-api-client/src/main/java/io/qase/client/v1/models/TestCaseParams.java
@@ -14,6 +14,8 @@
 package io.qase.client.v1.models;
 
 import java.util.Objects;
+import java.util.List;
+import java.util.Map;
 
 
 
@@ -50,7 +52,7 @@ import com.google.gson.JsonParseException;
 
 import io.qase.client.v1.JSON;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.4.0")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.13.0")
 public class TestCaseParams extends AbstractOpenApiSchema {
     private static final Logger log = Logger.getLogger(TestCaseParams.class.getName());
 
@@ -63,10 +65,10 @@ public class TestCaseParams extends AbstractOpenApiSchema {
             }
             final TypeAdapter<JsonElement> elementAdapter = gson.getAdapter(JsonElement.class);
 
-            final Type typeInstance = new TypeToken<List<Object>>() {
-            }.getType();
-            final TypeAdapter<List<Object>> adapterList = (TypeAdapter<List<Object>>) gson.getDelegateAdapter(this, TypeToken.get(typeInstance));
-            final TypeAdapter<Object> adapterObject = gson.getDelegateAdapter(this, TypeToken.get(Object.class));
+            final Type typeInstanceListObject = new TypeToken<List<Object>>(){}.getType();
+            final TypeAdapter<List<Object>> adapterListObject = (TypeAdapter<List<Object>>) gson.getDelegateAdapter(this, TypeToken.get(typeInstanceListObject));
+            final Type typeInstanceMapStringListString = new TypeToken<Map<String, List<String>>>(){}.getType();
+            final TypeAdapter<Map<String, List<String>>> adapterMap = (TypeAdapter<Map<String, List<String>>>) gson.getDelegateAdapter(this, TypeToken.get(typeInstanceMapStringListString));
 
             return (TypeAdapter<T>) new TypeAdapter<TestCaseParams>() {
                 @Override
@@ -77,19 +79,18 @@ public class TestCaseParams extends AbstractOpenApiSchema {
                     }
 
                     // check if the actual instance is of the type `List<Object>`
-                    if (value.getActualInstance() instanceof List) {
-                        JsonPrimitive primitive = adapterList.toJsonTree((List<Object>) value.getActualInstance()).getAsJsonPrimitive();
+                    if (value.getActualInstance() instanceof List<?>) {
+                        JsonPrimitive primitive = adapterListObject.toJsonTree((List<Object>)value.getActualInstance()).getAsJsonPrimitive();
                         elementAdapter.write(out, primitive);
                         return;
                     }
-
-                    // check if the actual instance is of the type `Object`
-                    if (value.getActualInstance() instanceof Object) {
-                        JsonPrimitive primitive = adapterObject.toJsonTree((Object) value.getActualInstance()).getAsJsonPrimitive();
-                        elementAdapter.write(out, primitive);
+                    // check if the actual instance is of the type `Map<String, List<String>>`
+                    if (value.getActualInstance() instanceof Map) {
+                        JsonElement element = adapterMap.toJsonTree((Map<String, List<String>>)value.getActualInstance());
+                        elementAdapter.write(out, element);
                         return;
                     }
-                    throw new IOException("Failed to serialize as the type doesn't match anyOf schemae: List<Object>, Object");
+                    throw new IOException("Failed to serialize as the type doesn't match anyOf schemas: List<Object>, Map<String, List<String>>");
                 }
 
                 @Override
@@ -103,22 +104,18 @@ public class TestCaseParams extends AbstractOpenApiSchema {
                     // deserialize List<Object>
                     try {
                         // validate the JSON object to see if any exception is thrown
-                        if (!jsonElement.getAsJsonPrimitive().isNumber()) {
-                            throw new IllegalArgumentException(String.format("Expected json element to be of type Number in the JSON string but got `%s`", jsonElement.toString()));
-                        }
-                        actualAdapter = adapterList;
                         if (!jsonElement.isJsonArray()) {
                             throw new IllegalArgumentException(String.format("Expected json element to be a array type in the JSON string but got `%s`", jsonElement.toString()));
                         }
 
                         JsonArray array = jsonElement.getAsJsonArray();
                         // validate array items
-                        for (JsonElement element : array) {
+                        for(JsonElement element : array) {
                             if (!element.getAsJsonPrimitive().isNumber()) {
                                 throw new IllegalArgumentException(String.format("Expected array items to be of type Number in the JSON string but got `%s`", jsonElement.toString()));
                             }
                         }
-                        actualAdapter = adapterList;
+                        actualAdapter = adapterListObject;
                         TestCaseParams ret = new TestCaseParams();
                         ret.setActualInstance(actualAdapter.fromJsonTree(jsonElement));
                         return ret;
@@ -127,20 +124,18 @@ public class TestCaseParams extends AbstractOpenApiSchema {
                         errorMessages.add(String.format("Deserialization for List<Object> failed with `%s`.", e.getMessage()));
                         log.log(Level.FINER, "Input data does not match schema 'List<Object>'", e);
                     }
-                    // deserialize Object
+                    // deserialize Map<String, List<String>>
                     try {
                         // validate the JSON object to see if any exception is thrown
-                        if (!jsonElement.getAsJsonPrimitive().isNumber()) {
-                            throw new IllegalArgumentException(String.format("Expected json element to be of type Number in the JSON string but got `%s`", jsonElement.toString()));
-                        }
-                        actualAdapter = adapterObject;
+                        validateJsonElement(jsonElement);
+                        actualAdapter = adapterMap;
                         TestCaseParams ret = new TestCaseParams();
                         ret.setActualInstance(actualAdapter.fromJsonTree(jsonElement));
                         return ret;
                     } catch (Exception e) {
                         // deserialization failed, continue
-                        errorMessages.add(String.format("Deserialization for Object failed with `%s`.", e.getMessage()));
-                        log.log(Level.FINER, "Input data does not match schema 'Object'", e);
+                        errorMessages.add(String.format("Deserialization for Map<String, List<String>> failed with `%s`.", e.getMessage()));
+                        log.log(Level.FINER, "Input data does not match schema 'Map<String, List<String>>'", e);
                     }
 
                     throw new IOException(String.format("Failed deserialization for TestCaseParams: no class matches result, expected at least 1. Detailed failure message for anyOf schemas: %s. JSON: %s", errorMessages, jsonElement.toString()));
@@ -156,11 +151,6 @@ public class TestCaseParams extends AbstractOpenApiSchema {
         super("anyOf", Boolean.FALSE);
     }
 
-    public TestCaseParams(List<Object> o) {
-        super("anyOf", Boolean.FALSE);
-        setActualInstance(o);
-    }
-
     public TestCaseParams(Object o) {
         super("anyOf", Boolean.FALSE);
         setActualInstance(o);
@@ -168,7 +158,7 @@ public class TestCaseParams extends AbstractOpenApiSchema {
 
     static {
         schemas.put("List<Object>", List.class);
-        schemas.put("Object", Object.class);
+        schemas.put("Map<String, List<String>>", Map.class);
     }
 
     @Override
@@ -179,8 +169,8 @@ public class TestCaseParams extends AbstractOpenApiSchema {
     /**
      * Set the instance that matches the anyOf child schema, check
      * the instance parameter is valid against the anyOf child schemas:
-     * List<Object>, Object
-     * <p>
+     * List<Object>, Map<String, List<String>>
+     *
      * It could be an instance of the 'anyOf' schemas.
      */
     @Override
@@ -193,45 +183,35 @@ public class TestCaseParams extends AbstractOpenApiSchema {
             }
         }
 
-        if (instance instanceof Object) {
+        if (instance instanceof Map) {
             super.setActualInstance(instance);
             return;
         }
 
-        throw new RuntimeException("Invalid instance type. Must be List<Object>, Object");
+        throw new RuntimeException("Invalid instance type. Must be List<Object>, Map<String, List<String>>");
     }
 
     /**
      * Get the actual instance, which can be the following:
-     * List<Object>, Object
+     * List<Object>, Map<String, List<String>>
      *
-     * @return The actual instance (List<Object>, Object)
+     * @return The actual instance (List<Object>, Map<String, List<String>>)
      */
+    @SuppressWarnings("unchecked")
     @Override
     public Object getActualInstance() {
         return super.getActualInstance();
     }
 
     /**
-     * Get the actual instance of `List<Object>`. If the actual instance is not `List<Object>`,
+     * Get the actual instance of `Map<String, List<String>>`. If the actual instance is not `Map<String, List<String>>`,
      * the ClassCastException will be thrown.
      *
-     * @return The actual instance of `List<Object>`
-     * @throws ClassCastException if the instance is not `List<Object>`
+     * @return The actual instance of `Map<String, List<String>>`
+     * @throws ClassCastException if the instance is not `Map<String, List<String>>`
      */
-    public List<Object> getList() throws ClassCastException {
-        return (List<Object>) super.getActualInstance();
-    }
-
-    /**
-     * Get the actual instance of `Object`. If the actual instance is not `Object`,
-     * the ClassCastException will be thrown.
-     *
-     * @return The actual instance of `Object`
-     * @throws ClassCastException if the instance is not `Object`
-     */
-    public Object getObject() throws ClassCastException {
-        return (Object) super.getActualInstance();
+    public Map<String, List<String>> getMapStringListString() throws ClassCastException {
+        return (Map<String, List<String>>)super.getActualInstance();
     }
 
     /**
@@ -245,15 +225,12 @@ public class TestCaseParams extends AbstractOpenApiSchema {
         ArrayList<String> errorMessages = new ArrayList<>();
         // validate the json string with List<Object>
         try {
-            if (!jsonElement.getAsJsonPrimitive().isNumber()) {
-                throw new IllegalArgumentException(String.format("Expected json element to be of type Number in the JSON string but got `%s`", jsonElement.toString()));
-            }
             if (!jsonElement.isJsonArray()) {
                 throw new IllegalArgumentException(String.format("Expected json element to be a array type in the JSON string but got `%s`", jsonElement.toString()));
             }
             JsonArray array = jsonElement.getAsJsonArray();
             // validate array items
-            for (JsonElement element : array) {
+            for(JsonElement element : array) {
                 if (!element.getAsJsonPrimitive().isNumber()) {
                     throw new IllegalArgumentException(String.format("Expected array items to be of type Number in the JSON string but got `%s`", jsonElement.toString()));
                 }
@@ -263,18 +240,32 @@ public class TestCaseParams extends AbstractOpenApiSchema {
             errorMessages.add(String.format("Deserialization for List<Object> failed with `%s`.", e.getMessage()));
             // continue to the next one
         }
-        // validate the json string with Object
+        // validate the json string with Map<String, List<String>>
         try {
-            if (!jsonElement.getAsJsonPrimitive().isNumber()) {
-                throw new IllegalArgumentException(String.format("Expected json element to be of type Number in the JSON string but got `%s`", jsonElement.toString()));
+            if (!jsonElement.isJsonObject()) {
+                throw new IllegalArgumentException(String.format("Expected json element to be an object type in the JSON string but got `%s`", jsonElement.toString()));
+            }
+
+            JsonObject jsonObject = jsonElement.getAsJsonObject();
+            for (Map.Entry<String, JsonElement> entry : jsonObject.entrySet()) {
+                JsonElement value = entry.getValue();
+                if (!value.isJsonArray()) {
+                    throw new IllegalArgumentException(String.format("Expected object values to be arrays in the JSON string but got `%s` for key `%s`", value.toString(), entry.getKey()));
+                }
+
+                JsonArray array = value.getAsJsonArray();
+                for (JsonElement element : array) {
+                    if (!element.isJsonPrimitive() || !element.getAsJsonPrimitive().isString()) {
+                        throw new IllegalArgumentException(String.format("Expected array items to be of type String in the JSON string but got `%s`", element.toString()));
+                    }
+                }
             }
             return;
         } catch (Exception e) {
-            errorMessages.add(String.format("Deserialization for Object failed with `%s`.", e.getMessage()));
+            errorMessages.add(String.format("Deserialization for Map<String, List<String>> failed with `%s`.", e.getMessage()));
             // continue to the next one
         }
-        throw new IOException(String.format("The JSON string is invalid for TestCaseParams with anyOf schemas: List<Object>, Object. no class match the result, expected at least 1. Detailed failure message for anyOf schemas: %s. JSON: %s", errorMessages, jsonElement.toString()));
-
+        throw new IOException(String.format("The JSON string is invalid for TestCaseParams with anyOf schemas: List<Object>, Map<String, List<String>>. no class match the result, expected at least 1. Detailed failure message for anyOf schemas: %s. JSON: %s", errorMessages, jsonElement.toString()));
     }
 
     /**

--- a/qase-api-v2-client/pom.xml
+++ b/qase-api-v2-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.qase</groupId>
         <artifactId>qase-java</artifactId>
-        <version>4.1.5</version>
+        <version>4.1.6</version>
     </parent>
 
     <artifactId>qase-api-v2-client</artifactId>

--- a/qase-cucumber-v3-reporter/pom.xml
+++ b/qase-cucumber-v3-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.5</version>
+        <version>4.1.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v4-reporter/pom.xml
+++ b/qase-cucumber-v4-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.5</version>
+        <version>4.1.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v5-reporter/pom.xml
+++ b/qase-cucumber-v5-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.5</version>
+        <version>4.1.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v6-reporter/pom.xml
+++ b/qase-cucumber-v6-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.5</version>
+        <version>4.1.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v7-reporter/pom.xml
+++ b/qase-cucumber-v7-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.5</version>
+        <version>4.1.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-java-commons/pom.xml
+++ b/qase-java-commons/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.qase</groupId>
         <artifactId>qase-java</artifactId>
-        <version>4.1.5</version>
+        <version>4.1.6</version>
     </parent>
 
     <artifactId>qase-java-commons</artifactId>

--- a/qase-junit4-reporter/pom.xml
+++ b/qase-junit4-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.5</version>
+        <version>4.1.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-junit5-reporter/pom.xml
+++ b/qase-junit5-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.5</version>
+        <version>4.1.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-testng-reporter/pom.xml
+++ b/qase-testng-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.5</version>
+        <version>4.1.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
This pull request for `qase-java` updates the version to 4.1.6 and addresses a JSON parsing issue in the `qase-api-client` module related to handling `TestCaseParams` with `anyOf` schemas. It introduces significant changes to the `TestCaseParams` class to support `Map<String, List<String>>` as a valid schema type alongside `List<Object>`. Additionally, all module `pom.xml` files have been updated to reflect the new version.

### Key Changes:

#### Bug Fixes and Enhancements:
* Fixed a JSON parsing error in `qase-api-client` when handling `TestCaseParams` with `anyOf` schemas by adding support for `Map<String, List<String>>`. This includes updates to serialization, deserialization, and validation logic in `TestCaseParams`. [[1]](diffhunk://#diff-cd265bffb230a5ca3fc550a5d891376cdb9024256bf909f1082c5a9d1626f763R17-R18) [[2]](diffhunk://#diff-cd265bffb230a5ca3fc550a5d891376cdb9024256bf909f1082c5a9d1626f763L53-R55) [[3]](diffhunk://#diff-cd265bffb230a5ca3fc550a5d891376cdb9024256bf909f1082c5a9d1626f763L66-R71) [[4]](diffhunk://#diff-cd265bffb230a5ca3fc550a5d891376cdb9024256bf909f1082c5a9d1626f763L80-R93) [[5]](diffhunk://#diff-cd265bffb230a5ca3fc550a5d891376cdb9024256bf909f1082c5a9d1626f763L106-L109) [[6]](diffhunk://#diff-cd265bffb230a5ca3fc550a5d891376cdb9024256bf909f1082c5a9d1626f763L121-R118) [[7]](diffhunk://#diff-cd265bffb230a5ca3fc550a5d891376cdb9024256bf909f1082c5a9d1626f763L130-R138) [[8]](diffhunk://#diff-cd265bffb230a5ca3fc550a5d891376cdb9024256bf909f1082c5a9d1626f763L159-R161) [[9]](diffhunk://#diff-cd265bffb230a5ca3fc550a5d891376cdb9024256bf909f1082c5a9d1626f763L182-R173) [[10]](diffhunk://#diff-cd265bffb230a5ca3fc550a5d891376cdb9024256bf909f1082c5a9d1626f763L196-R214) [[11]](diffhunk://#diff-cd265bffb230a5ca3fc550a5d891376cdb9024256bf909f1082c5a9d1626f763L248-L250) [[12]](diffhunk://#diff-cd265bffb230a5ca3fc550a5d891376cdb9024256bf909f1082c5a9d1626f763L266-R268)

#### Documentation:
* Updated `changelog.md` to include details about the bug fix in version 4.1.6.

#### Version Updates:
* Updated the version in the root `pom.xml` and all module `pom.xml` files to 4.1.6. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L10-R10) [[2]](diffhunk://#diff-514718fdfdacca86f2493ed9c6b28cc51a1345d76c874502fac7f18fb2281ac3L8-R8) [[3]](diffhunk://#diff-b2f841fbc79604c93661caea3c4160164f6067df2d25120c4525a3cadb4298d4L9-R9) [[4]](diffhunk://#diff-52c515b32b1f02b9f152f58e3e0e18a219cb44a72102b327c800d746db5fc8dcL8-R8) [[5]](diffhunk://#diff-86b8d7f9216c05d31872fdbe761c485f366052ebe73550b87426703a2aa75641L8-R8) [[6]](diffhunk://#diff-2a13ac9cd6493cd0ee2b5f04cbdf7468938e3b1e7265bac614812a75ba4ee713L8-R8) [[7]](diffhunk://#diff-8dca3b4b2c0f85527d8bbf623069a53ae88d17ff67f00c67b71a1806199886adL8-R8) [[8]](diffhunk://#diff-b14d9176febd68d8f2592505f4cad251e87e159ae3b1d07778ffea38abcc0ec9L8-R8) [[9]](diffhunk://#diff-fd60886a06671d6036def9287c94fe81b41d8febdd96e19da87d65aefbf36bdaL9-R9) [[10]](diffhunk://#diff-79a1b271637ed57e83005174230b63752c7e9165c49d2d19daae2a57c8d85bc7L8-R8) [[11]](diffhunk://#diff-c37a1a3bee150a3b54679b00ff4e69fbfa400fba50dc3d14a9c7a15571ca0039L8-R8) [[12]](diffhunk://#diff-2d7da0f3d513459b39793e52a7e3ffb2d05af6c1f851b303fe68ef7815db7814L8-R8)