### PR TITLE
feat: add support tags for test runs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+# qase-java 4.1.8
+
+## What's new
+
+Added support tags for test runs.
+
 # qase-java 4.1.7
 
 ## What's new

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.qase</groupId>
     <artifactId>qase-java</artifactId>
     <packaging>pom</packaging>
-    <version>4.1.7</version>
+    <version>4.1.8</version>
     <modules>
         <module>qase-java-commons</module>
         <module>qase-api-client</module>

--- a/qase-api-client/pom.xml
+++ b/qase-api-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.7</version>
+        <version>4.1.8</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-api-v2-client/pom.xml
+++ b/qase-api-v2-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.qase</groupId>
         <artifactId>qase-java</artifactId>
-        <version>4.1.7</version>
+        <version>4.1.8</version>
     </parent>
 
     <artifactId>qase-api-v2-client</artifactId>

--- a/qase-cucumber-v3-reporter/pom.xml
+++ b/qase-cucumber-v3-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.7</version>
+        <version>4.1.8</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v4-reporter/pom.xml
+++ b/qase-cucumber-v4-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.7</version>
+        <version>4.1.8</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v4-reporter/src/main/java/io/qase/cucumber4/QaseEventListener.java
+++ b/qase-cucumber-v4-reporter/src/main/java/io/qase/cucumber4/QaseEventListener.java
@@ -12,6 +12,7 @@ import gherkin.pickles.PickleTag;
 import io.qase.commons.CasesStorage;
 import io.qase.commons.StepStorage;
 import io.qase.commons.utils.CucumberUtils;
+import io.qase.commons.utils.StringUtils;
 import io.qase.commons.models.domain.*;
 import io.qase.commons.reporters.CoreReporterFactory;
 import io.qase.commons.reporters.Reporter;
@@ -143,6 +144,12 @@ public class QaseEventListener implements ConcurrentEventListener {
         resultCreate.fields = fields;
         resultCreate.relations = relations;
         resultCreate.params = parameters;
+
+        ArrayList<String> suites = new ArrayList<>();
+        suites.addAll(Arrays.asList(event.getTestCase().getUri().toString().split("/")));
+        suites.add(caseTitle);
+        
+        resultCreate.signature = StringUtils.generateSignature(new ArrayList<>(caseIds), suites, parameters);
 
         return resultCreate;
     }

--- a/qase-cucumber-v5-reporter/pom.xml
+++ b/qase-cucumber-v5-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.7</version>
+        <version>4.1.8</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v5-reporter/src/main/java/io/qase/cucumber5/QaseEventListener.java
+++ b/qase-cucumber-v5-reporter/src/main/java/io/qase/cucumber5/QaseEventListener.java
@@ -5,6 +5,7 @@ import io.cucumber.plugin.event.*;
 import io.qase.commons.CasesStorage;
 import io.qase.commons.StepStorage;
 import io.qase.commons.utils.CucumberUtils;
+import io.qase.commons.utils.StringUtils;
 import io.qase.commons.models.domain.*;
 import io.qase.commons.reporters.CoreReporterFactory;
 import io.cucumber.plugin.ConcurrentEventListener;
@@ -130,6 +131,12 @@ public class QaseEventListener implements ConcurrentEventListener {
         resultCreate.fields = fields;
         resultCreate.relations = relations;
         resultCreate.params = parameters;
+
+        ArrayList<String> suites = new ArrayList<>();
+        suites.addAll(Arrays.asList(event.getTestCase().getUri().toString().split("/")));
+        suites.add(caseTitle);
+        
+        resultCreate.signature = StringUtils.generateSignature(new ArrayList<>(caseIds), suites, parameters);
 
         return resultCreate;
     }

--- a/qase-cucumber-v6-reporter/pom.xml
+++ b/qase-cucumber-v6-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.7</version>
+        <version>4.1.8</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v6-reporter/src/main/java/io/qase/cucumber6/QaseEventListener.java
+++ b/qase-cucumber-v6-reporter/src/main/java/io/qase/cucumber6/QaseEventListener.java
@@ -9,6 +9,7 @@ import io.cucumber.plugin.event.*;
 import io.qase.commons.CasesStorage;
 import io.qase.commons.StepStorage;
 import io.qase.commons.utils.CucumberUtils;
+import io.qase.commons.utils.StringUtils;
 import io.qase.commons.models.domain.*;
 import io.qase.commons.reporters.CoreReporterFactory;
 import io.cucumber.plugin.ConcurrentEventListener;
@@ -147,6 +148,12 @@ public class QaseEventListener implements ConcurrentEventListener {
         resultCreate.fields = fields;
         resultCreate.relations = relations;
         resultCreate.params = parameters;
+
+        ArrayList<String> suites = new ArrayList<>();
+        suites.addAll(Arrays.asList(event.getTestCase().getUri().toString().split("/")));
+        suites.add(caseTitle);
+        
+        resultCreate.signature = StringUtils.generateSignature(new ArrayList<>(caseIds), suites, parameters);
 
         return resultCreate;
     }

--- a/qase-cucumber-v7-reporter/pom.xml
+++ b/qase-cucumber-v7-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.7</version>
+        <version>4.1.8</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v7-reporter/src/main/java/io/qase/cucumber7/QaseEventListener.java
+++ b/qase-cucumber-v7-reporter/src/main/java/io/qase/cucumber7/QaseEventListener.java
@@ -13,6 +13,7 @@ import io.cucumber.plugin.event.TestStepStarted;
 import io.qase.commons.CasesStorage;
 import io.qase.commons.StepStorage;
 import io.qase.commons.utils.CucumberUtils;
+import io.qase.commons.utils.StringUtils;
 import io.qase.commons.models.domain.*;
 import io.qase.commons.reporters.CoreReporterFactory;
 import io.cucumber.plugin.ConcurrentEventListener;
@@ -151,6 +152,12 @@ public class QaseEventListener implements ConcurrentEventListener {
         resultCreate.fields = fields;
         resultCreate.relations = relations;
         resultCreate.params = parameters;
+
+        ArrayList<String> suites = new ArrayList<>();
+        suites.addAll(Arrays.asList(event.getTestCase().getUri().toString().split("/")));
+        suites.add(caseTitle);
+        
+        resultCreate.signature = StringUtils.generateSignature(new ArrayList<>(caseIds), suites, parameters);
 
         return resultCreate;
     }

--- a/qase-java-commons/README.md
+++ b/qase-java-commons/README.md
@@ -48,6 +48,7 @@ All configuration options are listed in the table below:
 | Qase test run title                                                                                                        | `testops.run.title`        | `QASE_TESTOPS_RUN_TITLE`        | `QASE_TESTOPS_RUN_TITLE`        | `Automated run <Current date and time>` | No       | Any string                 |
 | Qase test run description                                                                                                  | `testops.run.description`  | `QASE_TESTOPS_RUN_DESCRIPTION`  | `QASE_TESTOPS_RUN_DESCRIPTION`  | `<Framework name> automated run`        | No       | Any string                 |
 | Qase test run complete                                                                                                     | `testops.run.complete`     | `QASE_TESTOPS_RUN_COMPLETE`     | `QASE_TESTOPS_RUN_COMPLETE`     | `True`                                  |          | `True`, `False`            |
+| Qase test run tags                                                                                                         | `testops.run.tags`         | `QASE_TESTOPS_RUN_TAGS`         | `QASE_TESTOPS_RUN_TAGS`         | undefined                               | No       | Comma-separated strings    |
 | Qase test plan ID                                                                                                          | `testops.plan.id`          | `QASE_TESTOPS_PLAN_ID`          | `QASE_TESTOPS_PLAN_ID`          | undefined                               | No       | Any integer                |
 | Size of batch for sending test results                                                                                     | `testops.batch.size`       | `QASE_TESTOPS_BATCH_SIZE`       | `QASE_TESTOPS_BATCH_SIZE`       | `200`                                   | No       | Any integer                |
 | Enable defects for failed test cases                                                                                       | `testops.defect`           | `QASE_TESTOPS_DEFECT`           | `QASE_TESTOPS_DEFECT`           | `False`                                 | No       | `True`, `False`            |
@@ -78,7 +79,11 @@ All configuration options are listed in the table below:
     "run": {
       "title": "Regress run",
       "description": "Regress run description",
-      "complete": true
+      "complete": true,
+      "tags": [
+        "tag1",
+        "tag2"
+      ]
     },
     "defect": false,
     "project": "<project_code>",

--- a/qase-java-commons/pom.xml
+++ b/qase-java-commons/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.qase</groupId>
         <artifactId>qase-java</artifactId>
-        <version>4.1.7</version>
+        <version>4.1.8</version>
     </parent>
 
     <artifactId>qase-java-commons</artifactId>

--- a/qase-java-commons/src/main/java/io/qase/commons/client/ApiClientV1.java
+++ b/qase-java-commons/src/main/java/io/qase/commons/client/ApiClientV1.java
@@ -18,6 +18,7 @@ import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -75,12 +76,16 @@ public class ApiClientV1 implements io.qase.commons.client.ApiClient {
             model.setPlanId((long) this.config.testops.plan.id);
         }
 
+        if (this.config.testops.run.tags != null && this.config.testops.run.tags.length > 0) {
+            model.setTags(Arrays.asList(this.config.testops.run.tags));
+        }
+
         try {
             return Objects.requireNonNull(
                     new RunsApi(client)
                             .createRun(this.config.testops.project, model)
-                            .getResult()
-            ).getId();
+                            .getResult())
+                    .getId();
         } catch (ApiException e) {
             throw new QaseException("Failed to create test run: " + e.getResponseBody(), e.getCause());
         }
@@ -114,12 +119,11 @@ public class ApiClientV1 implements io.qase.commons.client.ApiClient {
                     .getPlan(this.config.testops.project, this.config.testops.plan.id);
 
             return Objects.requireNonNull(
-                            Objects.requireNonNull(response.getResult())
-                                    .getCases())
+                    Objects.requireNonNull(response.getResult())
+                            .getCases())
                     .stream()
                     .map(PlanDetailedAllOfCases::getCaseId)
-                    .collect(Collectors.toList()
-                    );
+                    .collect(Collectors.toList());
         } catch (ApiException e) {
             throw new QaseException("Failed to get test case ids for execution: " + e.getResponseBody(), e.getCause());
         }
@@ -157,14 +161,14 @@ public class ApiClientV1 implements io.qase.commons.client.ApiClient {
         }
 
         try {
-            List<Attachmentupload> response = api.uploadAttachment(this.config.testops.project, Collections.singletonList(file)).getResult();
+            List<Attachmentupload> response = api
+                    .uploadAttachment(this.config.testops.project, Collections.singletonList(file)).getResult();
             return processUploadResponse(response, file, removeFile);
         } catch (ApiException e) {
             logger.error("Failed to upload attachment: %s", e.getMessage());
             return "";
         }
     }
-
 
     private String processUploadResponse(List<Attachmentupload> response, File file, boolean removeFile) {
         if (file != null && file.exists() && removeFile) {

--- a/qase-java-commons/src/main/java/io/qase/commons/config/ConfigFactory.java
+++ b/qase-java-commons/src/main/java/io/qase/commons/config/ConfigFactory.java
@@ -7,6 +7,7 @@ import org.json.JSONTokener;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Optional;
 
 public class ConfigFactory {
@@ -64,12 +65,15 @@ public class ConfigFactory {
         qaseConfig.testops.run.description = getEnv("QASE_TESTOPS_RUN_DESCRIPTION", qaseConfig.testops.run.description);
         qaseConfig.testops.run.id = getIntEnv("QASE_TESTOPS_RUN_ID", qaseConfig.testops.run.id);
         qaseConfig.testops.run.complete = getBooleanEnv("QASE_TESTOPS_RUN_COMPLETE", qaseConfig.testops.run.complete);
+        qaseConfig.testops.run.tags = getEnvArray("QASE_TESTOPS_RUN_TAGS", qaseConfig.testops.run.tags);
         qaseConfig.testops.plan.id = getIntEnv("QASE_TESTOPS_PLAN_ID", qaseConfig.testops.plan.id);
         qaseConfig.testops.batch.setSize(getIntEnv("QASE_TESTOPS_BATCH_SIZE", qaseConfig.testops.batch.getSize()));
 
         qaseConfig.report.setDriver(getEnv("QASE_REPORT_DRIVER", qaseConfig.report.getDriver()));
-        qaseConfig.report.connection.local.setFormat(getEnv("QASE_REPORT_CONNECTION_FORMAT", qaseConfig.report.connection.local.getFormat()));
-        qaseConfig.report.connection.local.path = getEnv("QASE_REPORT_CONNECTION_PATH", qaseConfig.report.connection.local.path);
+        qaseConfig.report.connection.local
+                .setFormat(getEnv("QASE_REPORT_CONNECTION_FORMAT", qaseConfig.report.connection.local.getFormat()));
+        qaseConfig.report.connection.local.path = getEnv("QASE_REPORT_CONNECTION_PATH",
+                qaseConfig.report.connection.local.path);
 
         return qaseConfig;
     }
@@ -86,21 +90,27 @@ public class ConfigFactory {
         qaseConfig.testops.api.token = getProperty("QASE_TESTOPS_API_TOKEN", qaseConfig.testops.api.token);
         qaseConfig.testops.api.host = getProperty("QASE_TESTOPS_API_HOST", qaseConfig.testops.api.host);
         qaseConfig.testops.run.title = getProperty("QASE_TESTOPS_RUN_TITLE", qaseConfig.testops.run.title);
-        qaseConfig.testops.run.description = getProperty("QASE_TESTOPS_RUN_DESCRIPTION", qaseConfig.testops.run.description);
+        qaseConfig.testops.run.description = getProperty("QASE_TESTOPS_RUN_DESCRIPTION",
+                qaseConfig.testops.run.description);
         qaseConfig.testops.run.id = getIntProperty("QASE_TESTOPS_RUN_ID", qaseConfig.testops.run.id);
-        qaseConfig.testops.run.complete = getBooleanProperty("QASE_TESTOPS_RUN_COMPLETE", qaseConfig.testops.run.complete);
+        qaseConfig.testops.run.complete = getBooleanProperty("QASE_TESTOPS_RUN_COMPLETE",
+                qaseConfig.testops.run.complete);
+        qaseConfig.testops.run.tags = getPropertyArray("QASE_TESTOPS_RUN_TAGS", qaseConfig.testops.run.tags);
         qaseConfig.testops.plan.id = getIntProperty("QASE_TESTOPS_PLAN_ID", qaseConfig.testops.plan.id);
         qaseConfig.testops.batch.setSize(getIntProperty("QASE_TESTOPS_BATCH_SIZE", qaseConfig.testops.batch.getSize()));
 
         qaseConfig.report.setDriver(getProperty("QASE_REPORT_DRIVER", qaseConfig.report.getDriver()));
-        qaseConfig.report.connection.local.setFormat(getProperty("QASE_REPORT_CONNECTION_FORMAT", qaseConfig.report.connection.local.getFormat()));
-        qaseConfig.report.connection.local.path = getProperty("QASE_REPORT_CONNECTION_PATH", qaseConfig.report.connection.local.path);
+        qaseConfig.report.connection.local.setFormat(
+                getProperty("QASE_REPORT_CONNECTION_FORMAT", qaseConfig.report.connection.local.getFormat()));
+        qaseConfig.report.connection.local.path = getProperty("QASE_REPORT_CONNECTION_PATH",
+                qaseConfig.report.connection.local.path);
 
         return qaseConfig;
     }
 
     private static void validateConfig(QaseConfig qaseConfig) {
-        if ((qaseConfig.mode == Mode.TESTOPS || qaseConfig.fallback == Mode.TESTOPS) && (qaseConfig.testops.project == null || qaseConfig.testops.api.token == null)) {
+        if ((qaseConfig.mode == Mode.TESTOPS || qaseConfig.fallback == Mode.TESTOPS)
+                && (qaseConfig.testops.project == null || qaseConfig.testops.api.token == null)) {
             logger.error("Project and API token are required for TestOps mode");
             qaseConfig.mode = Mode.OFF;
             qaseConfig.fallback = Mode.OFF;
@@ -109,6 +119,14 @@ public class ConfigFactory {
 
     private static String getEnv(String key, String defaultValue) {
         return Optional.ofNullable(System.getenv(key)).orElse(defaultValue);
+    }
+
+    private static String[] getEnvArray(String key, String[] defaultValue) {
+        return Optional.ofNullable(System.getenv(key))
+                .map(value -> Arrays.stream(value.split(","))
+                        .map(String::trim)
+                        .toArray(String[]::new))
+                .orElse(defaultValue);
     }
 
     private static boolean getBooleanEnv(String key, boolean defaultValue) {
@@ -121,6 +139,14 @@ public class ConfigFactory {
 
     private static String getProperty(String key, String defaultValue) {
         return Optional.ofNullable(System.getProperty(key)).orElse(defaultValue);
+    }
+
+    private static String[] getPropertyArray(String key, String[] defaultValue) {
+        return Optional.ofNullable(System.getProperty(key))
+                .map(value -> Arrays.stream(value.split(","))
+                        .map(String::trim)
+                        .toArray(String[]::new))
+                .orElse(defaultValue);
     }
 
     private static boolean getBooleanProperty(String key, boolean defaultValue) {

--- a/qase-java-commons/src/main/java/io/qase/commons/config/RunConfig.java
+++ b/qase-java-commons/src/main/java/io/qase/commons/config/RunConfig.java
@@ -7,4 +7,5 @@ public class RunConfig {
     public String description = "";
     public boolean complete = true;
     public Integer id = 0;
+    public String[] tags = {};
 }

--- a/qase-java-commons/src/main/java/io/qase/commons/utils/IntegrationUtils.java
+++ b/qase-java-commons/src/main/java/io/qase/commons/utils/IntegrationUtils.java
@@ -105,13 +105,12 @@ public final class IntegrationUtils {
         String packageName = testMethod.getDeclaringClass().getPackage().getName().toLowerCase().replace('.', ':');
         String className = testMethod.getDeclaringClass().getSimpleName().toLowerCase();
         String methodName = testMethod.getName().toLowerCase();
-        String qaseIdPart = qaseIds != null ? "::" + qaseIds.stream().map(String::valueOf).collect(Collectors.joining("-")) : "";
-        String parametersPart = parameters != null && !parameters.isEmpty()
-                ? "::" + parameters.entrySet().stream()
-                .map(entry -> entry.getKey().toLowerCase() + "::" + entry.getValue().toLowerCase().replace(" ", "_"))
-                .collect(Collectors.joining("::"))
-                : "";
 
-        return String.format("%s::%s.java::%s::%s%s", packageName, className, className, methodName, qaseIdPart + parametersPart);
+        ArrayList<String> suites = new ArrayList<>();
+        suites.add(packageName);
+        suites.add(className);
+        suites.add(methodName);
+
+        return StringUtils.generateSignature(new ArrayList<>(qaseIds), suites, parameters);
     }
 }

--- a/qase-java-commons/src/main/java/io/qase/commons/utils/StringUtils.java
+++ b/qase-java-commons/src/main/java/io/qase/commons/utils/StringUtils.java
@@ -5,6 +5,9 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class StringUtils {
@@ -18,5 +21,27 @@ public class StringUtils {
         DateTimeFormatter formatter = DateTimeFormatter.ISO_DATE_TIME;
 
         return now.format(formatter);
+    }
+
+    public static String generateSignature(ArrayList<Long> ids, ArrayList<String> suites,
+            Map<String, String> parameters) {
+        ArrayList<String> parts = new ArrayList<>();
+
+        if (ids != null && ids.size() > 0) {
+            parts.add(ids.stream().map(String::valueOf).collect(Collectors.joining("-")));
+        }
+
+        if (suites != null && suites.size() > 0) {
+            parts.addAll(suites.stream().map(suite -> suite.trim().replace(" ", "_").toLowerCase())
+                    .collect(Collectors.toList()));
+        }
+
+        if (parameters != null && !parameters.isEmpty()) {
+            parts.addAll(parameters.entrySet().stream()
+                    .map(entry -> String.format("{\"%s\":\"%s\"}", entry.getKey(), entry.getValue()))
+                    .collect(Collectors.toList()));
+        }
+
+        return parts.stream().collect(Collectors.joining("::"));
     }
 }

--- a/qase-java-commons/src/test/java/io/qase/commons/utils/StringUtilsTest.java
+++ b/qase-java-commons/src/test/java/io/qase/commons/utils/StringUtilsTest.java
@@ -1,0 +1,97 @@
+package io.qase.commons.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class StringUtilsTest {
+
+    @Test
+    void isBlankShouldReturnTrueForNull() {
+        assertTrue(StringUtils.isBlank(null));
+    }
+
+    @Test
+    void isBlankShouldReturnTrueForEmptyString() {
+        assertTrue(StringUtils.isBlank(""));
+    }
+
+    @Test
+    void isBlankShouldReturnTrueForWhitespaceString() {
+        assertTrue(StringUtils.isBlank("   "));
+    }
+
+    @Test
+    void isBlankShouldReturnFalseForNonEmptyString() {
+        assertFalse(StringUtils.isBlank("test"));
+    }
+
+    @Test
+    void getDateTimeShouldReturnValidFormat() {
+        String dateTime = StringUtils.getDateTime();
+        assertNotNull(dateTime);
+        assertTrue(dateTime.matches("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?"));
+    }
+
+    @Test
+    void generateSignatureWithIdsOnly() {
+        ArrayList<Long> ids = new ArrayList<>();
+        ids.add(1L);
+        ids.add(2L);
+        ids.add(3L);
+
+        String signature = StringUtils.generateSignature(ids, null, null);
+        assertEquals("1-2-3", signature);
+    }
+
+    @Test
+    void generateSignatureWithSuitesOnly() {
+        ArrayList<String> suites = new ArrayList<>();
+        suites.add("Test Suite");
+        suites.add("Another Suite");
+
+        String signature = StringUtils.generateSignature(null, suites, null);
+        assertEquals("test_suite::another_suite", signature);
+    }
+
+    @Test
+    void generateSignatureWithParametersOnly() {
+        HashMap<String, String> parameters = new HashMap<>();
+        parameters.put("param1", "value1");
+        parameters.put("param2", "value2");
+
+        String signature = StringUtils.generateSignature(null, null, parameters);
+        assertEquals("{\"param1\":\"value1\"}::{\"param2\":\"value2\"}", signature);
+    }
+
+    @Test
+    void generateSignatureWithAllParameters() {
+        ArrayList<Long> ids = new ArrayList<>();
+        ids.add(1L);
+        ids.add(2L);
+
+        ArrayList<String> suites = new ArrayList<>();
+        suites.add("Test Suite");
+
+        HashMap<String, String> parameters = new HashMap<>();
+        parameters.put("param1", "value1");
+
+        String signature = StringUtils.generateSignature(ids, suites, parameters);
+        assertEquals("1-2::test_suite::{\"param1\":\"value1\"}", signature);
+    }
+
+    @Test
+    void generateSignatureWithEmptyInputs() {
+        String signature = StringUtils.generateSignature(null, null, null);
+        assertEquals("", signature);
+    }
+
+    @Test
+    void generateSignatureWithEmptyLists() {
+        String signature = StringUtils.generateSignature(new ArrayList<>(), new ArrayList<>(), new HashMap<>());
+        assertEquals("", signature);
+    }
+}

--- a/qase-junit4-reporter/pom.xml
+++ b/qase-junit4-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.7</version>
+        <version>4.1.8</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-junit4-reporter/src/main/java/io/qase/junit4/QaseListener.java
+++ b/qase-junit4-reporter/src/main/java/io/qase/junit4/QaseListener.java
@@ -1,6 +1,5 @@
 package io.qase.junit4;
 
-
 import io.qase.commons.CasesStorage;
 import io.qase.commons.StepStorage;
 import io.qase.commons.annotation.*;
@@ -8,6 +7,8 @@ import io.qase.commons.models.annotation.Field;
 import io.qase.commons.models.domain.*;
 import io.qase.commons.reporters.CoreReporterFactory;
 import io.qase.commons.reporters.Reporter;
+import io.qase.commons.utils.StringUtils;
+
 import org.junit.runner.Description;
 import org.junit.runner.notification.Failure;
 import org.junit.runner.notification.RunListener;
@@ -219,13 +220,8 @@ public class QaseListener extends RunListener {
         String className = description.getClassName().toLowerCase().replace(".", ":");
         String[] parts = description.getMethodName().split("\\.");
         String methodName = parts[parts.length - 1].toLowerCase();
-        String qaseIdPart = qaseIds != null ? "::" + qaseIds.stream().map(String::valueOf).collect(Collectors.joining("-")) : "";
-        String parametersPart = parameters != null && !parameters.isEmpty()
-                ? "::" + parameters.entrySet().stream()
-                .map(entry -> entry.getKey().toLowerCase() + "::" + entry.getValue().toLowerCase().replace(" ", "_"))
-                .collect(Collectors.joining("::"))
-                : "";
 
-        return String.format("%s.java::%s::%s%s", className, className, methodName, qaseIdPart + parametersPart);
+        return StringUtils.generateSignature(new ArrayList<>(qaseIds),
+                new ArrayList<>(Arrays.asList(className, methodName)), parameters);
     }
 }

--- a/qase-junit5-reporter/pom.xml
+++ b/qase-junit5-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.7</version>
+        <version>4.1.8</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-testng-reporter/pom.xml
+++ b/qase-testng-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.7</version>
+        <version>4.1.8</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
This pull request updates the `qase-java` library to version 4.1.8, introduces support for tags in test runs, and refactors multiple components for improved readability and functionality. Below is a summary of the most important changes:

### New Features:
* Added support for tags in test runs. Tags can now be specified in the configuration and are included when creating test runs. (`changelog.md` [[1]](diffhunk://#diff-3bd14d078188074c410028847113ceae68865d0ad5b844a27183ef87fbe2fcc3R1-R6) `ApiClientV1.java` [[2]](diffhunk://#diff-e8f0c158c138dae8c37de4b8c5c26f69c10eb5adac3d26454c5606a0ffcc5a10R79-R88) `ConfigFactory.java` [[3]](diffhunk://#diff-bfe58b545a2da573e6df76e028460bc805e940761d37a3bb639bd1351419a3beR68-R76))

### Version Updates:
* Updated version references from `4.1.7` to `4.1.8` across all `pom.xml` files to reflect the new release. (`pom.xml` [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L10-R10) `qase-api-client/pom.xml` [[2]](diffhunk://#diff-514718fdfdacca86f2493ed9c6b28cc51a1345d76c874502fac7f18fb2281ac3L8-R8) `qase-api-v2-client/pom.xml` [[3]](diffhunk://#diff-b2f841fbc79604c93661caea3c4160164f6067df2d25120c4525a3cadb4298d4L9-R9) `qase-cucumber-v3-reporter/pom.xml` [[4]](diffhunk://#diff-52c515b32b1f02b9f152f58e3e0e18a219cb44a72102b327c800d746db5fc8dcL8-R8) `qase-cucumber-v4-reporter/pom.xml` [[5]](diffhunk://#diff-86b8d7f9216c05d31872fdbe761c485f366052ebe73550b87426703a2aa75641L8-R8) `qase-cucumber-v5-reporter/pom.xml` [[6]](diffhunk://#diff-2a13ac9cd6493cd0ee2b5f04cbdf7468938e3b1e7265bac614812a75ba4ee713L8-R8) `qase-cucumber-v6-reporter/pom.xml` [[7]](diffhunk://#diff-8dca3b4b2c0f85527d8bbf623069a53ae88d17ff67f00c67b71a1806199886adL8-R8) `qase-cucumber-v7-reporter/pom.xml` [[8]](diffhunk://#diff-b14d9176febd68d8f2592505f4cad251e87e159ae3b1d07778ffea38abcc0ec9L8-R8) `qase-java-commons/pom.xml` [[9]](diffhunk://#diff-fd60886a06671d6036def9287c94fe81b41d8febdd96e19da87d65aefbf36bdaL9-R9))

### Enhancements to Cucumber Reporters:
* Introduced the `generateSignature` method from `StringUtils` to generate unique signatures for test cases in Cucumber reporters (v3, v4, v5, v6, and v7). (`QaseEventListener.java` for v3 [[1]](diffhunk://#diff-b35de0b4d32354ced403864d38dc90f14618da6b97b0d4bbb0271a9df4c51371R146-R152) v4 [[2]](diffhunk://#diff-a20116218ca55e1693b46b0ffd95a398d70b87ffcf0beea8472f5cace7d0c18eR148-R153) v5 [[3]](diffhunk://#diff-77be9305e192abac93ea7d9d46ffd0a022e0e024d8acec88c5d3e8462a745d35R135-R140) v6 [[4]](diffhunk://#diff-4a994f83ac775195e3c9750d52cc3b6f89582537ce359b2da65247c8baea73a3R152-R157) v7 [[5]](diffhunk://#diff-00e1926b51da7fdba7868c958b8b087281da8c9349792ebe970159c322451e7cR156-R161))
* Added imports for `StringUtils` in all Cucumber reporter implementations. (`QaseEventListener.java` for v3 [[1]](diffhunk://#diff-b35de0b4d32354ced403864d38dc90f14618da6b97b0d4bbb0271a9df4c51371R16) v4 [[2]](diffhunk://#diff-a20116218ca55e1693b46b0ffd95a398d70b87ffcf0beea8472f5cace7d0c18eR15) v5 [[3]](diffhunk://#diff-77be9305e192abac93ea7d9d46ffd0a022e0e024d8acec88c5d3e8462a745d35R8) v6 [[4]](diffhunk://#diff-4a994f83ac775195e3c9750d52cc3b6f89582537ce359b2da65247c8baea73a3R12) v7 [[5]](diffhunk://#diff-00e1926b51da7fdba7868c958b8b087281da8c9349792ebe970159c322451e7cR16))

### Code Refactoring:
* Improved code readability by reformatting method calls and streamlining logic in `ApiClientV1.java`. (`ApiClientV1.java` [[1]](diffhunk://#diff-e8f0c158c138dae8c37de4b8c5c26f69c10eb5adac3d26454c5606a0ffcc5a10L121-R126) [[2]](diffhunk://#diff-e8f0c158c138dae8c37de4b8c5c26f69c10eb5adac3d26454c5606a0ffcc5a10L160-L168))
* Reformatted multiline statements for better clarity in `QaseEventListener.java` for Cucumber v3. (`QaseEventListener.java` [[1]](diffhunk://#diff-b35de0b4d32354ced403864d38dc90f14618da6b97b0d4bbb0271a9df4c51371L108-R114) [[2]](diffhunk://#diff-b35de0b4d32354ced403864d38dc90f14618da6b97b0d4bbb0271a9df4c51371L166-R173) [[3]](diffhunk://#diff-b35de0b4d32354ced403864d38dc90f14618da6b97b0d4bbb0271a9df4c51371L205-R215))

These changes collectively enhance the functionality, maintainability, and usability of the `qase-java` library.