### PR TITLE
chore: update version to 4.1.22 and add public report link support

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+# qase-java 4.1.22
+
+## What's new
+
+- Added support for public report link for test runs.
+
 # qase-java 4.1.21
 
 ## What's new

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.qase</groupId>
     <artifactId>qase-java</artifactId>
     <packaging>pom</packaging>
-    <version>4.1.21</version>
+    <version>4.1.22</version>
     <modules>
         <module>qase-java-commons</module>
         <module>qase-api-client</module>

--- a/qase-api-client/pom.xml
+++ b/qase-api-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.21</version>
+        <version>4.1.22</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-api-v2-client/pom.xml
+++ b/qase-api-v2-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.qase</groupId>
         <artifactId>qase-java</artifactId>
-        <version>4.1.21</version>
+        <version>4.1.22</version>
     </parent>
 
     <artifactId>qase-api-v2-client</artifactId>

--- a/qase-cucumber-v3-reporter/pom.xml
+++ b/qase-cucumber-v3-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.21</version>
+        <version>4.1.22</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v4-reporter/pom.xml
+++ b/qase-cucumber-v4-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.21</version>
+        <version>4.1.22</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v5-reporter/pom.xml
+++ b/qase-cucumber-v5-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.21</version>
+        <version>4.1.22</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v6-reporter/pom.xml
+++ b/qase-cucumber-v6-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.21</version>
+        <version>4.1.22</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v7-reporter/pom.xml
+++ b/qase-cucumber-v7-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.21</version>
+        <version>4.1.22</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-java-commons/README.md
+++ b/qase-java-commons/README.md
@@ -54,6 +54,7 @@ All configuration options are listed in the table below:
 | Qase test run tags                                                                                                         | `testops.run.tags`         | `QASE_TESTOPS_RUN_TAGS`         | `QASE_TESTOPS_RUN_TAGS`         | undefined                               | No       | Comma-separated strings    |
 | External link type for test run                                                                                          | `testops.run.externalLink.type` | `QASE_TESTOPS_RUN_EXTERNAL_LINK_TYPE` | `QASE_TESTOPS_RUN_EXTERNAL_LINK_TYPE` | `null` | No       | `jiraCloud`, `jiraServer` |
 | External link URL for test run                                                                                           | `testops.run.externalLink.link` | `QASE_TESTOPS_RUN_EXTERNAL_LINK` | `QASE_TESTOPS_RUN_EXTERNAL_LINK` | `null` | No       | Any valid URL |
+| Enable public report link generation                                                                                     | `testops.showPublicReportLink` | `QASE_TESTOPS_SHOW_PUBLIC_REPORT_LINK` | `QASE_TESTOPS_SHOW_PUBLIC_REPORT_LINK` | `False` | No       | `True`, `False` |
 | Qase test run configurations                                                                                               | `testops.run.configurations` | `QASE_TESTOPS_RUN_CONFIGURATIONS` | `QASE_TESTOPS_RUN_CONFIGURATIONS` | undefined                               | No       | Comma-separated key=value pairs |
 | Qase test run configurations create if not exists                                                                         | `testops.run.configurations.createIfNotExists` | `QASE_TESTOPS_CONFIGURATIONS_CREATE_IF_NOT_EXISTS` | `QASE_TESTOPS_CONFIGURATIONS_CREATE_IF_NOT_EXISTS` | `False`                                 | No       | `True`, `False`            |
 | Qase test plan ID                                                                                                          | `testops.plan.id`          | `QASE_TESTOPS_PLAN_ID`          | `QASE_TESTOPS_PLAN_ID`          | undefined                               | No       | Any integer                |
@@ -88,6 +89,7 @@ All configuration options are listed in the table below:
       "token": "<token>",
       "host": "qase.io"
     },
+    "showPublicReportLink": true,
     "run": {
       "title": "Regress run",
       "description": "Regress run description",

--- a/qase-java-commons/pom.xml
+++ b/qase-java-commons/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.qase</groupId>
         <artifactId>qase-java</artifactId>
-        <version>4.1.21</version>
+        <version>4.1.22</version>
     </parent>
 
     <artifactId>qase-java-commons</artifactId>

--- a/qase-java-commons/src/main/java/io/qase/commons/client/ApiClient.java
+++ b/qase-java-commons/src/main/java/io/qase/commons/client/ApiClient.java
@@ -15,4 +15,6 @@ public interface ApiClient {
     List<Long> getTestCaseIdsForExecution() throws QaseException;
 
     void updateExternalIssue(Long runId) throws QaseException;
+
+    String enablePublicReport(Long runId) throws QaseException;
 }

--- a/qase-java-commons/src/main/java/io/qase/commons/client/ApiClientV1.java
+++ b/qase-java-commons/src/main/java/io/qase/commons/client/ApiClientV1.java
@@ -150,6 +150,23 @@ public class ApiClientV1 implements io.qase.commons.client.ApiClient {
     }
 
     @Override
+    public String enablePublicReport(Long runId) throws QaseException {
+        try {
+            RunPublic runPublic = new RunPublic().status(true);
+            RunPublicResponse response = new RunsApi(client)
+                    .updateRunPublicity(this.config.testops.project, runId.intValue(), runPublic);
+            
+            if (response != null && response.getResult() != null && response.getResult().getUrl() != null) {
+                return response.getResult().getUrl().toString();
+            } else {
+                throw new QaseException("Public report URL not found in response");
+            }
+        } catch (ApiException e) {
+            throw new QaseException("Failed to enable public report: " + e.getResponseBody(), e.getCause());
+        }
+    }
+
+    @Override
     public void uploadResults(Long runId, List<TestResult> results) throws QaseException {
         throw new NotImplementedException("Use ApiClientV2 for uploading results");
     }

--- a/qase-java-commons/src/main/java/io/qase/commons/client/ApiClientV2.java
+++ b/qase-java-commons/src/main/java/io/qase/commons/client/ApiClientV2.java
@@ -77,6 +77,11 @@ public class ApiClientV2 implements ApiClient {
         return this.apiClientV1.getTestCaseIdsForExecution();
     }
 
+    @Override
+    public String enablePublicReport(Long runId) throws QaseException {
+        return this.apiClientV1.enablePublicReport(runId);
+    }
+
     private ResultCreate convertResult(TestResult result) {
         List<String> attachments = result.attachments.stream()
                 .map(this.apiClientV1::uploadAttachment)

--- a/qase-java-commons/src/main/java/io/qase/commons/config/ConfigFactory.java
+++ b/qase-java-commons/src/main/java/io/qase/commons/config/ConfigFactory.java
@@ -78,6 +78,7 @@ public class ConfigFactory {
         qaseConfig.testops.run.complete = getBooleanEnv("QASE_TESTOPS_RUN_COMPLETE", qaseConfig.testops.run.complete);
         qaseConfig.testops.run.tags = getEnvArray("QASE_TESTOPS_RUN_TAGS", qaseConfig.testops.run.tags);
         qaseConfig.testops.run.externalLink = getExternalLinkEnv("QASE_TESTOPS_RUN_EXTERNAL_LINK_TYPE", "QASE_TESTOPS_RUN_EXTERNAL_LINK", qaseConfig.testops.run.externalLink);
+        qaseConfig.testops.showPublicReportLink = getBooleanEnv("QASE_TESTOPS_SHOW_PUBLIC_REPORT_LINK", qaseConfig.testops.showPublicReportLink);
         qaseConfig.testops.plan.id = getIntEnv("QASE_TESTOPS_PLAN_ID", qaseConfig.testops.plan.id);
         qaseConfig.testops.batch.setSize(getIntEnv("QASE_TESTOPS_BATCH_SIZE", qaseConfig.testops.batch.getSize()));
         qaseConfig.testops.statusFilter = Arrays.asList(getEnvArray("QASE_TESTOPS_STATUS_FILTER", qaseConfig.testops.statusFilter.toArray(new String[0])));
@@ -122,6 +123,7 @@ public class ConfigFactory {
                 qaseConfig.testops.run.complete);
         qaseConfig.testops.run.tags = getPropertyArray("QASE_TESTOPS_RUN_TAGS", qaseConfig.testops.run.tags);
         qaseConfig.testops.run.externalLink = getExternalLinkProperty("QASE_TESTOPS_RUN_EXTERNAL_LINK_TYPE", "QASE_TESTOPS_RUN_EXTERNAL_LINK", qaseConfig.testops.run.externalLink);
+        qaseConfig.testops.showPublicReportLink = getBooleanProperty("QASE_TESTOPS_SHOW_PUBLIC_REPORT_LINK", qaseConfig.testops.showPublicReportLink);
         qaseConfig.testops.plan.id = getIntProperty("QASE_TESTOPS_PLAN_ID", qaseConfig.testops.plan.id);
         qaseConfig.testops.batch.setSize(getIntProperty("QASE_TESTOPS_BATCH_SIZE", qaseConfig.testops.batch.getSize()));
         qaseConfig.testops.statusFilter = Arrays.asList(getPropertyArray("QASE_TESTOPS_STATUS_FILTER", qaseConfig.testops.statusFilter.toArray(new String[0])));
@@ -378,6 +380,10 @@ public class ConfigFactory {
                     }
                     qaseConfig.testops.run.externalLink = externalLink;
                 }
+            }
+
+            if (testOps.has("showPublicReportLink")) {
+                qaseConfig.testops.showPublicReportLink = testOps.getBoolean("showPublicReportLink");
             }
 
             if (testOps.has("plan")) {

--- a/qase-java-commons/src/main/java/io/qase/commons/config/TestopsConfig.java
+++ b/qase-java-commons/src/main/java/io/qase/commons/config/TestopsConfig.java
@@ -6,6 +6,7 @@ import java.util.List;
 public class TestopsConfig {
     public String project = "";
     public boolean defect = false;
+    public boolean showPublicReportLink = false;
     public ApiConfig api;
     public RunConfig run;
     public PlanConfig plan;

--- a/qase-java-commons/src/main/java/io/qase/commons/reporters/TestopsReporter.java
+++ b/qase-java-commons/src/main/java/io/qase/commons/reporters/TestopsReporter.java
@@ -45,6 +45,16 @@ public class TestopsReporter implements InternalReporter {
     public void completeTestRun() throws QaseException {
         this.client.completeTestRun(this.testRunId);
         logger.info("Test run %d completed", this.testRunId);
+        
+        // Enable public report if configured
+        if (this.config.showPublicReportLink) {
+            try {
+                String publicReportUrl = this.client.enablePublicReport(this.testRunId);
+                logger.info("Public report link: %s", publicReportUrl);
+            } catch (QaseException e) {
+                logger.warn("Failed to generate public report link: %s", e.getMessage());
+            }
+        }
     }
 
     @Override

--- a/qase-java-commons/src/test/java/io/qase/commons/client/ApiClientV1PublicReportTest.java
+++ b/qase-java-commons/src/test/java/io/qase/commons/client/ApiClientV1PublicReportTest.java
@@ -1,0 +1,65 @@
+package io.qase.commons.client;
+
+import io.qase.client.v1.ApiException;
+import io.qase.client.v1.api.RunsApi;
+import io.qase.client.v1.models.RunPublic;
+import io.qase.client.v1.models.RunPublicResponse;
+import io.qase.client.v1.models.RunPublicResponseAllOfResult;
+import io.qase.commons.QaseException;
+import io.qase.commons.config.QaseConfig;
+import io.qase.commons.config.TestopsConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ApiClientV1PublicReportTest {
+
+    private ApiClientV1 apiClient;
+    private QaseConfig config;
+
+    @BeforeEach
+    void setUp() {
+        config = new QaseConfig();
+        config.testops = new TestopsConfig();
+        config.testops.project = "TEST_PROJECT";
+        config.testops.api.token = "test_token";
+        config.testops.api.host = "qase.io";
+
+        apiClient = new ApiClientV1(config);
+    }
+
+    @Test
+    void testEnablePublicReport_WithValidConfig() {
+        // This test verifies that the method can be called without throwing exceptions
+        // In a real scenario, you would mock the API client or use integration tests
+        
+        // Arrange
+        Long runId = 123L;
+        
+        // Act & Assert
+        // Since we can't easily mock the API client without reflection,
+        // we'll test that the method exists and can be called
+        assertDoesNotThrow(() -> {
+            try {
+                apiClient.enablePublicReport(runId);
+            } catch (QaseException e) {
+                // Expected to fail in test environment without valid API credentials
+                assertTrue(e.getMessage().contains("Failed to enable public report"));
+            }
+        });
+    }
+
+    @Test
+    void testEnablePublicReport_WithNullRunId() {
+        // Arrange
+        Long runId = null;
+        
+        // Act & Assert
+        assertThrows(NullPointerException.class, () -> {
+            apiClient.enablePublicReport(runId);
+        });
+    }
+}

--- a/qase-java-commons/src/test/java/io/qase/commons/config/ConfigFactoryPublicReportTest.java
+++ b/qase-java-commons/src/test/java/io/qase/commons/config/ConfigFactoryPublicReportTest.java
@@ -1,0 +1,80 @@
+package io.qase.commons.config;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ConfigFactoryPublicReportTest {
+
+    @Test
+    void testLoadFromEnv_ShowPublicReportLink() {
+        // Arrange
+        String originalValue = System.getenv("QASE_TESTOPS_SHOW_PUBLIC_REPORT_LINK");
+        
+        try {
+            // Set environment variable
+            System.setProperty("QASE_TESTOPS_SHOW_PUBLIC_REPORT_LINK", "true");
+            
+            // Act
+            QaseConfig config = ConfigFactory.loadConfig();
+            
+            // Assert
+            assertTrue(config.testops.showPublicReportLink, "Environment variable should be loaded");
+        } finally {
+            // Cleanup
+            if (originalValue != null) {
+                System.setProperty("QASE_TESTOPS_SHOW_PUBLIC_REPORT_LINK", originalValue);
+            } else {
+                System.clearProperty("QASE_TESTOPS_SHOW_PUBLIC_REPORT_LINK");
+            }
+        }
+    }
+
+    @Test
+    void testLoadFromEnv_ShowPublicReportLinkFalse() {
+        // Arrange
+        String originalValue = System.getenv("QASE_TESTOPS_SHOW_PUBLIC_REPORT_LINK");
+        
+        try {
+            // Set environment variable
+            System.setProperty("QASE_TESTOPS_SHOW_PUBLIC_REPORT_LINK", "false");
+            
+            // Act
+            QaseConfig config = ConfigFactory.loadConfig();
+            
+            // Assert
+            assertFalse(config.testops.showPublicReportLink, "Environment variable should be loaded as false");
+        } finally {
+            // Cleanup
+            if (originalValue != null) {
+                System.setProperty("QASE_TESTOPS_SHOW_PUBLIC_REPORT_LINK", originalValue);
+            } else {
+                System.clearProperty("QASE_TESTOPS_SHOW_PUBLIC_REPORT_LINK");
+            }
+        }
+    }
+
+    @Test
+    void testDefaultValue_ShowPublicReportLink() {
+        // Arrange
+        String originalValue = System.getenv("QASE_TESTOPS_SHOW_PUBLIC_REPORT_LINK");
+        
+        try {
+            // Clear environment variable
+            System.clearProperty("QASE_TESTOPS_SHOW_PUBLIC_REPORT_LINK");
+            
+            // Act
+            QaseConfig config = ConfigFactory.loadConfig();
+            
+            // Assert
+            assertFalse(config.testops.showPublicReportLink, "Default value should be false");
+        } finally {
+            // Cleanup
+            if (originalValue != null) {
+                System.setProperty("QASE_TESTOPS_SHOW_PUBLIC_REPORT_LINK", originalValue);
+            } else {
+                System.clearProperty("QASE_TESTOPS_SHOW_PUBLIC_REPORT_LINK");
+            }
+        }
+    }
+}

--- a/qase-java-commons/src/test/java/io/qase/commons/config/RunConfigPublicReportTest.java
+++ b/qase-java-commons/src/test/java/io/qase/commons/config/RunConfigPublicReportTest.java
@@ -1,0 +1,29 @@
+package io.qase.commons.config;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TestopsConfigPublicReportTest {
+
+    @Test
+    void testDefaultShowPublicReportLink() {
+        // Arrange & Act
+        TestopsConfig config = new TestopsConfig();
+
+        // Assert
+        assertFalse(config.showPublicReportLink, "Default value should be false");
+    }
+
+    @Test
+    void testSetShowPublicReportLink() {
+        // Arrange
+        TestopsConfig config = new TestopsConfig();
+
+        // Act
+        config.showPublicReportLink = true;
+
+        // Assert
+        assertTrue(config.showPublicReportLink);
+    }
+}

--- a/qase-java-commons/src/test/java/io/qase/commons/reporters/TestopsReporterPublicReportTest.java
+++ b/qase-java-commons/src/test/java/io/qase/commons/reporters/TestopsReporterPublicReportTest.java
@@ -1,0 +1,113 @@
+package io.qase.commons.reporters;
+
+import io.qase.commons.QaseException;
+import io.qase.commons.client.ApiClient;
+import io.qase.commons.config.TestopsConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TestopsReporterPublicReportTest {
+
+    private TestopsConfig config;
+
+    @BeforeEach
+    void setUp() {
+        config = new TestopsConfig();
+        config.run.id = 123;
+        config.showPublicReportLink = true;
+    }
+
+    @Test
+    void testCompleteTestRun_WithPublicReportEnabled() {
+        // This test verifies that the TestopsReporter can be created and configured
+        // In a real scenario, you would mock the ApiClient
+        
+        // Arrange
+        ApiClient mockClient = new ApiClient() {
+            @Override
+            public Long createTestRun() throws QaseException {
+                return 123L;
+            }
+
+            @Override
+            public void completeTestRun(Long runId) throws QaseException {
+                // Mock implementation
+            }
+
+            @Override
+            public void uploadResults(Long runId, java.util.List<io.qase.commons.models.domain.TestResult> results) throws QaseException {
+                // Mock implementation
+            }
+
+            @Override
+            public java.util.List<Long> getTestCaseIdsForExecution() throws QaseException {
+                return java.util.Collections.emptyList();
+            }
+
+            @Override
+            public void updateExternalIssue(Long runId) throws QaseException {
+                // Mock implementation
+            }
+
+            @Override
+            public String enablePublicReport(Long runId) throws QaseException {
+                return "https://app.qase.io/public/report/abc123";
+            }
+        };
+
+        TestopsReporter reporter = new TestopsReporter(config, mockClient);
+
+        // Act & Assert
+        assertDoesNotThrow(() -> {
+            reporter.completeTestRun();
+        });
+    }
+
+    @Test
+    void testCompleteTestRun_WithPublicReportDisabled() {
+        // Arrange
+        config.showPublicReportLink = false;
+        
+        ApiClient mockClient = new ApiClient() {
+            @Override
+            public Long createTestRun() throws QaseException {
+                return 123L;
+            }
+
+            @Override
+            public void completeTestRun(Long runId) throws QaseException {
+                // Mock implementation
+            }
+
+            @Override
+            public void uploadResults(Long runId, java.util.List<io.qase.commons.models.domain.TestResult> results) throws QaseException {
+                // Mock implementation
+            }
+
+            @Override
+            public java.util.List<Long> getTestCaseIdsForExecution() throws QaseException {
+                return java.util.Collections.emptyList();
+            }
+
+            @Override
+            public void updateExternalIssue(Long runId) throws QaseException {
+                // Mock implementation
+            }
+
+            @Override
+            public String enablePublicReport(Long runId) throws QaseException {
+                fail("enablePublicReport should not be called when showPublicReportLink is false");
+                return null;
+            }
+        };
+
+        TestopsReporter reporter = new TestopsReporter(config, mockClient);
+
+        // Act & Assert
+        assertDoesNotThrow(() -> {
+            reporter.completeTestRun();
+        });
+    }
+}

--- a/qase-junit4-reporter/pom.xml
+++ b/qase-junit4-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.21</version>
+        <version>4.1.22</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-junit5-reporter/pom.xml
+++ b/qase-junit5-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.21</version>
+        <version>4.1.22</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-testng-reporter/pom.xml
+++ b/qase-testng-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.21</version>
+        <version>4.1.22</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
- Updated version number to 4.1.22 in all relevant pom.xml files.
- Added support for generating public report links for test runs.
- Enhanced configuration options to enable public report link generation.
- Updated changelog to reflect the new version and features added.