### PR TITLE
chore: update version to 4.1.23 and add report attachment models

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.qase</groupId>
     <artifactId>qase-java</artifactId>
     <packaging>pom</packaging>
-    <version>4.1.22</version>
+    <version>4.1.23</version>
     <modules>
         <module>qase-java-commons</module>
         <module>qase-api-client</module>

--- a/qase-api-client/pom.xml
+++ b/qase-api-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.22</version>
+        <version>4.1.23</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-api-v2-client/pom.xml
+++ b/qase-api-v2-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.qase</groupId>
         <artifactId>qase-java</artifactId>
-        <version>4.1.22</version>
+        <version>4.1.23</version>
     </parent>
 
     <artifactId>qase-api-v2-client</artifactId>

--- a/qase-cucumber-v3-reporter/pom.xml
+++ b/qase-cucumber-v3-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.22</version>
+        <version>4.1.23</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v4-reporter/pom.xml
+++ b/qase-cucumber-v4-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.22</version>
+        <version>4.1.23</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v5-reporter/pom.xml
+++ b/qase-cucumber-v5-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.22</version>
+        <version>4.1.23</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v6-reporter/pom.xml
+++ b/qase-cucumber-v6-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.22</version>
+        <version>4.1.23</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v7-reporter/pom.xml
+++ b/qase-cucumber-v7-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.22</version>
+        <version>4.1.23</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-java-commons/pom.xml
+++ b/qase-java-commons/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.qase</groupId>
         <artifactId>qase-java</artifactId>
-        <version>4.1.22</version>
+        <version>4.1.23</version>
     </parent>
 
     <artifactId>qase-java-commons</artifactId>

--- a/qase-java-commons/src/main/java/io/qase/commons/models/domain/StepResult.java
+++ b/qase-java-commons/src/main/java/io/qase/commons/models/domain/StepResult.java
@@ -5,6 +5,7 @@ import java.util.*;
 
 public class StepResult {
     public String id = UUID.randomUUID().toString();
+    public String stepType = "text";
     public Data data;
     public String parentId;
     public StepExecution execution;

--- a/qase-java-commons/src/main/java/io/qase/commons/models/report/ReportAttachment.java
+++ b/qase-java-commons/src/main/java/io/qase/commons/models/report/ReportAttachment.java
@@ -1,0 +1,42 @@
+package io.qase.commons.models.report;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Attachment model for file report according to attachment.yaml specification
+ */
+public class ReportAttachment {
+    /**
+     * Unique identifier of the attachment
+     */
+    public String id;
+
+    /**
+     * Base64 encoded content of the attachment (nullable)
+     */
+    public String content;
+
+    /**
+     * Name of the file (nullable)
+     */
+    @SerializedName("file_name")
+    public String fileName;
+
+    /**
+     * Path to the file (nullable)
+     */
+    @SerializedName("file_path")
+    public String filePath;
+
+    /**
+     * MIME type of the attachment (nullable)
+     */
+    @SerializedName("mime_type")
+    public String mimeType;
+
+    /**
+     * Size of the attachment in bytes (nullable)
+     */
+    public Long size;
+}
+

--- a/qase-java-commons/src/main/java/io/qase/commons/models/report/ReportData.java
+++ b/qase-java-commons/src/main/java/io/qase/commons/models/report/ReportData.java
@@ -1,10 +1,25 @@
 package io.qase.commons.models.report;
 
+import com.google.gson.annotations.SerializedName;
+
+import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Data model for step according to step.yaml specification
+ */
 public class ReportData {
     public String action;
+    
+    @SerializedName("expected_result")
     public String expectedResult;
+    
+    @SerializedName("input_data")
     public String inputData;
-    public List<String> attachments;
+    
+    public List<ReportAttachment> attachments;
+
+    public ReportData() {
+        this.attachments = new ArrayList<>();
+    }
 }

--- a/qase-java-commons/src/main/java/io/qase/commons/models/report/ReportExecution.java
+++ b/qase-java-commons/src/main/java/io/qase/commons/models/report/ReportExecution.java
@@ -1,0 +1,41 @@
+package io.qase.commons.models.report;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Execution model for test result according to result.yaml specification
+ */
+public class ReportExecution {
+    /**
+     * Status of the test execution
+     */
+    public String status;
+
+    /**
+     * Start time of the test execution in milliseconds (nullable)
+     */
+    @SerializedName("start_time")
+    public Long startTime;
+
+    /**
+     * End time of the test execution in milliseconds (nullable)
+     */
+    @SerializedName("end_time")
+    public Long endTime;
+
+    /**
+     * Duration of the test execution in milliseconds (nullable)
+     */
+    public Long duration;
+
+    /**
+     * Stacktrace in case of failure (nullable)
+     */
+    public String stacktrace;
+
+    /**
+     * Thread name where the test was executed (nullable)
+     */
+    public String thread;
+}
+

--- a/qase-java-commons/src/main/java/io/qase/commons/models/report/ReportHostData.java
+++ b/qase-java-commons/src/main/java/io/qase/commons/models/report/ReportHostData.java
@@ -1,0 +1,25 @@
+package io.qase.commons.models.report;
+
+/**
+ * Host data model for run report according to root.yaml specification
+ */
+public class ReportHostData {
+    /**
+     * Name of the host data property
+     */
+    public String name;
+
+    /**
+     * Value of the host data property
+     */
+    public String value;
+
+    public ReportHostData() {
+    }
+
+    public ReportHostData(String name, String value) {
+        this.name = name;
+        this.value = value;
+    }
+}
+

--- a/qase-java-commons/src/main/java/io/qase/commons/models/report/ReportResult.java
+++ b/qase-java-commons/src/main/java/io/qase/commons/models/report/ReportResult.java
@@ -1,24 +1,49 @@
 package io.qase.commons.models.report;
 
-import io.qase.commons.models.domain.*;
+import com.google.gson.annotations.SerializedName;
+import io.qase.commons.models.domain.Relations;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Test result model for file report according to result.yaml specification
+ */
 public class ReportResult {
     public String id;
     public String title;
     public String signature;
     public String runId;
+    
+    /**
+     * Single testops ID (nullable)
+     */
+    @SerializedName("testops_id")
+    public Long testopsId;
+    
+    /**
+     * Array of testops IDs (nullable)
+     */
+    @SerializedName("testops_ids")
     public List<Long> testopsIds;
-    public TestResultExecution execution;
+    
+    public ReportExecution execution;
     public Map<String, String> fields;
-    public List<String> attachments;
+    public List<ReportAttachment> attachments;
     public List<ReportStepResult> steps;
     public Map<String, String> params;
+    
+    @SerializedName("param_groups")
     public List<List<String>> paramGroups;
+    
     public String author;
     public Relations relations;
     public boolean muted;
     public String message;
+
+    public ReportResult() {
+        this.attachments = new ArrayList<>();
+        this.steps = new ArrayList<>();
+    }
 }

--- a/qase-java-commons/src/main/java/io/qase/commons/models/report/ReportStepExecution.java
+++ b/qase-java-commons/src/main/java/io/qase/commons/models/report/ReportStepExecution.java
@@ -1,0 +1,43 @@
+package io.qase.commons.models.report;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Execution model for step result according to step.yaml specification
+ */
+public class ReportStepExecution {
+    /**
+     * Status of the step execution
+     */
+    public String status;
+
+    /**
+     * Start time of the step execution in milliseconds (nullable)
+     */
+    @SerializedName("start_time")
+    public Long startTime;
+
+    /**
+     * End time of the step execution in milliseconds (nullable)
+     */
+    @SerializedName("end_time")
+    public Long endTime;
+
+    /**
+     * Duration of the step execution in milliseconds (nullable)
+     */
+    public Long duration;
+
+    /**
+     * Attachments for this step execution
+     */
+    public List<ReportAttachment> attachments;
+
+    public ReportStepExecution() {
+        this.attachments = new ArrayList<>();
+    }
+}
+

--- a/qase-java-commons/src/main/java/io/qase/commons/models/report/ReportStepResult.java
+++ b/qase-java-commons/src/main/java/io/qase/commons/models/report/ReportStepResult.java
@@ -1,14 +1,32 @@
 package io.qase.commons.models.report;
 
-import io.qase.commons.models.domain.StepExecution;
+import com.google.gson.annotations.SerializedName;
 
+import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Step result model for file report according to step.yaml specification
+ */
 public class ReportStepResult {
     public String id;
+    
+    /**
+     * Type of the step
+     */
+    @SerializedName("step_type")
+    public String stepType;
+    
     public ReportData data;
+    
+    @SerializedName("parent_id")
     public String parentId;
-    public StepExecution execution;
-    public List<String> attachments;
+    
+    public ReportStepExecution execution;
+    
     public List<ReportStepResult> steps;
+
+    public ReportStepResult() {
+        this.steps = new ArrayList<>();
+    }
 }

--- a/qase-java-commons/src/main/java/io/qase/commons/models/report/Run.java
+++ b/qase-java-commons/src/main/java/io/qase/commons/models/report/Run.java
@@ -1,10 +1,15 @@
 package io.qase.commons.models.report;
 
+import com.google.gson.annotations.SerializedName;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+/**
+ * Run model for file report according to root.yaml specification
+ */
 public class Run {
     public String title;
     public RunExecution execution;
@@ -13,7 +18,9 @@ public class Run {
     public List<String> threads;
     public List<String> suites;
     public String environment;
-    public Map<String, String> hostData;
+    
+    @SerializedName("host_data")
+    public List<ReportHostData> hostData;
 
     public Run(String title, long startTime, long endTime, String environment) {
         this.title = title;
@@ -23,6 +30,7 @@ public class Run {
         this.threads = new ArrayList<>();
         this.suites = new ArrayList<>();
         this.environment = environment;
+        this.hostData = new ArrayList<>();
     }
 
     public void addResults(List<ReportResult> results) {
@@ -30,14 +38,13 @@ public class Run {
             ShortReportResult shortResult = new ShortReportResult();
             shortResult.id = result.id;
             shortResult.title = result.title;
-            shortResult.status = result.execution.status.toString().toLowerCase();
-            shortResult.duration = result.execution.duration;
+            shortResult.status = result.execution.status;
+            shortResult.duration = result.execution.duration != null ? result.execution.duration.intValue() : 0;
             shortResult.thread = result.execution.thread;
 
             this.execution.track(shortResult);
             this.stats.track(shortResult, result.muted);
             this.results.add(shortResult);
-
         }
 
         this.threads = this.results.stream()
@@ -46,7 +53,17 @@ public class Run {
                 .collect(Collectors.toList());
     }
 
-    public void addHostData() {
-        this.hostData = hostData;
+    /**
+     * Adds host data to the report
+     * @param hostData Map of host data properties
+     */
+    public void addHostData(Map<String, String> hostData) {
+        if (hostData == null) {
+            return;
+        }
+        
+        for (Map.Entry<String, String> entry : hostData.entrySet()) {
+            this.hostData.add(new ReportHostData(entry.getKey(), entry.getValue()));
+        }
     }
 }

--- a/qase-java-commons/src/main/java/io/qase/commons/writers/Writer.java
+++ b/qase-java-commons/src/main/java/io/qase/commons/writers/Writer.java
@@ -2,6 +2,7 @@ package io.qase.commons.writers;
 
 import io.qase.commons.QaseException;
 import io.qase.commons.models.domain.Attachment;
+import io.qase.commons.models.report.ReportAttachment;
 import io.qase.commons.models.report.ReportResult;
 import io.qase.commons.models.report.Run;
 
@@ -12,5 +13,10 @@ public interface Writer {
 
     void writeResult(ReportResult result) throws QaseException;
 
-    String writeAttachment(Attachment attachment);
+    /**
+     * Writes attachment to storage and returns ReportAttachment with metadata
+     * @param attachment Domain attachment to write
+     * @return ReportAttachment with file path and metadata, or null if failed
+     */
+    ReportAttachment writeAttachment(Attachment attachment);
 }

--- a/qase-java-commons/src/test/java/io/qase/commons/reporters/FileReporterTest.java
+++ b/qase-java-commons/src/test/java/io/qase/commons/reporters/FileReporterTest.java
@@ -6,6 +6,7 @@ import io.qase.commons.config.QaseConfig;
 import io.qase.commons.models.domain.Attachment;
 import io.qase.commons.models.domain.TestResult;
 import io.qase.commons.models.domain.TestResultStatus;
+import io.qase.commons.models.report.ReportAttachment;
 import io.qase.commons.models.report.ReportResult;
 import io.qase.commons.models.report.Run;
 import io.qase.commons.writers.Writer;
@@ -45,7 +46,12 @@ class FileReporterTest {
     @Test
     void testCompleteTestRun() throws QaseException {
         TestResult testResult = this.prepareResult();
-        when(writerMock.writeAttachment(any())).thenReturn("attachment-path");
+        
+        ReportAttachment mockAttachment = new ReportAttachment();
+        mockAttachment.id = "test-id";
+        mockAttachment.fileName = "test.txt";
+        mockAttachment.filePath = "attachment-path";
+        when(writerMock.writeAttachment(any())).thenReturn(mockAttachment);
 
         fileReporter.startTestRun();
         fileReporter.addResult(testResult);
@@ -70,7 +76,11 @@ class FileReporterTest {
     void testConvertTestResult() throws QaseException {
         TestResult testResult = this.prepareResult();
 
-        when(writerMock.writeAttachment(any())).thenReturn("attachment-path");
+        ReportAttachment mockAttachment = new ReportAttachment();
+        mockAttachment.id = "test-id";
+        mockAttachment.fileName = "test.txt";
+        mockAttachment.filePath = "attachment-path";
+        when(writerMock.writeAttachment(any())).thenReturn(mockAttachment);
 
         fileReporter.startTestRun();
         fileReporter.addResult(testResult);

--- a/qase-junit4-reporter/pom.xml
+++ b/qase-junit4-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.22</version>
+        <version>4.1.23</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-junit5-reporter/pom.xml
+++ b/qase-junit5-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.22</version>
+        <version>4.1.23</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-testng-reporter/pom.xml
+++ b/qase-testng-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.22</version>
+        <version>4.1.23</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
- Updated version number to 4.1.23 in all relevant pom.xml files.
- Introduced new report attachment models to support file attachments in reports.
- Enhanced existing report data structures to include attachments and execution details.
- Updated FileReporter and related classes to handle new attachment functionality.
- Added unit tests to validate the new attachment features and ensure proper functionality.