### PR TITLE
chore: update version to 4.1.25 and improve attachment upload mechanism

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+# qase-java 4.1.25
+
+## What's new
+
+- Improved the upload mechanism for attachments. Now the reporter will upload attachments in batches of 20 files.
+
 # qase-java 4.1.24
 
 ## What's new

--- a/examples/cucubmer3/cucubmer3-gradle/build.gradle
+++ b/examples/cucubmer3/cucubmer3-gradle/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     testImplementation("io.cucumber:cucumber-core:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-java:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-testng:$cucumberVersion")
-    testImplementation("io.qase:qase-cucumber-v3-reporter:4.1.24")
+    testImplementation("io.qase:qase-cucumber-v3-reporter:4.1.25")
 }
 
 test {

--- a/examples/cucubmer3/cucumber3-maven/pom.xml
+++ b/examples/cucubmer3/cucumber3-maven/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aspectj.version>1.9.22</aspectj.version>
-        <qase.version>4.1.24</qase.version>
+        <qase.version>4.1.25</qase.version>
     </properties>
 
     <dependencies>

--- a/examples/cucubmer4/cucubmer4-gradle/build.gradle
+++ b/examples/cucubmer4/cucubmer4-gradle/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     testImplementation("io.cucumber:cucumber-core:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-java:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-testng:$cucumberVersion")
-    testImplementation("io.qase:qase-cucumber-v4-reporter:4.1.24")
+    testImplementation("io.qase:qase-cucumber-v4-reporter:4.1.25")
 }
 
 test {

--- a/examples/cucubmer4/cucubmer4-gradle/qase.config.json
+++ b/examples/cucubmer4/cucubmer4-gradle/qase.config.json
@@ -13,7 +13,7 @@
   },
   "testops": {
     "api": {
-      "token": "45a0b4c1e0cc6c64580a82565d939779490097e0d7a7d8ccfe77393346b426fb",
+      "token": "<token>",
       "host": "qase.io"
     },
     "run": {
@@ -22,7 +22,7 @@
       "complete": true
     },
     "defect": false,
-    "project": "DEVX",
+    "project": "<project code>",
     "batch": {
       "size": 200
     },

--- a/examples/cucubmer4/cucumber4-maven/pom.xml
+++ b/examples/cucubmer4/cucumber4-maven/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aspectj.version>1.9.22</aspectj.version>
-        <qase.version>4.1.24</qase.version>
+        <qase.version>4.1.25</qase.version>
     </properties>
 
     <dependencies>

--- a/examples/cucubmer5/cucubmer5-gradle/build.gradle
+++ b/examples/cucubmer5/cucubmer5-gradle/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     testImplementation("io.cucumber:cucumber-core:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-java:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-testng:$cucumberVersion")
-    testImplementation("io.qase:qase-cucumber-v5-reporter:4.1.24")
+    testImplementation("io.qase:qase-cucumber-v5-reporter:4.1.25")
 }
 
 test {

--- a/examples/cucubmer5/cucumber5-maven/pom.xml
+++ b/examples/cucubmer5/cucumber5-maven/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aspectj.version>1.9.22</aspectj.version>
-        <qase.version>4.1.24</qase.version>
+        <qase.version>4.1.25</qase.version>
     </properties>
 
     <dependencies>

--- a/examples/cucubmer6/cucubmer6-gradle/build.gradle
+++ b/examples/cucubmer6/cucubmer6-gradle/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     testImplementation("io.cucumber:cucumber-core:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-java:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-testng:$cucumberVersion")
-    testImplementation("io.qase:qase-cucumber-v6-reporter:4.1.24")
+    testImplementation("io.qase:qase-cucumber-v6-reporter:4.1.25")
 }
 
 test {

--- a/examples/cucubmer6/cucumber6-maven/pom.xml
+++ b/examples/cucubmer6/cucumber6-maven/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aspectj.version>1.9.22</aspectj.version>
-        <qase.version>4.1.24</qase.version>
+        <qase.version>4.1.25</qase.version>
         <cucumber.version>6.11.0</cucumber.version>
     </properties>
 

--- a/examples/cucubmer7/cucumber7-gradle-junit4/build.gradle
+++ b/examples/cucubmer7/cucumber7-gradle-junit4/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     testImplementation("io.cucumber:cucumber-core:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-java:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-junit:$cucumberVersion")
-    testImplementation("io.qase:qase-cucumber-v7-reporter:4.1.24")
+    testImplementation("io.qase:qase-cucumber-v7-reporter:4.1.25")
 }
 
 test {

--- a/examples/cucubmer7/cucumber7-gradle-junit5/build.gradle
+++ b/examples/cucubmer7/cucumber7-gradle-junit5/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     testImplementation("io.cucumber:cucumber-core:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-java:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-junit-platform-engine:$cucumberVersion")
-    testImplementation("io.qase:qase-cucumber-v7-reporter:4.1.24")
+    testImplementation("io.qase:qase-cucumber-v7-reporter:4.1.25")
 }
 
 test {

--- a/examples/cucubmer7/cucumber7-gradle-testng/build.gradle
+++ b/examples/cucubmer7/cucumber7-gradle-testng/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     testImplementation("io.cucumber:cucumber-core:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-java:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-testng:$cucumberVersion")
-    testImplementation("io.qase:qase-cucumber-v7-reporter:4.1.24")
+    testImplementation("io.qase:qase-cucumber-v7-reporter:4.1.25")
 }
 
 test {

--- a/examples/cucubmer7/cucumber7-gradlekts-junit5/build.gradle.kts
+++ b/examples/cucubmer7/cucumber7-gradlekts-junit5/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
     testImplementation("io.cucumber:cucumber-core:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-java:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-junit-platform-engine:$cucumberVersion")
-    testImplementation("io.qase:qase-cucumber-v7-reporter:4.1.24")
+    testImplementation("io.qase:qase-cucumber-v7-reporter:4.1.25")
 }
 
 tasks.test {

--- a/examples/cucubmer7/cucumber7-maven-junit4/pom.xml
+++ b/examples/cucubmer7/cucumber7-maven-junit4/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aspectj.version>1.9.22</aspectj.version>
-        <qase.version>4.1.24</qase.version>
+        <qase.version>4.1.25</qase.version>
         <cucumber.version>7.14.0</cucumber.version>
     </properties>
 

--- a/examples/cucubmer7/cucumber7-maven-junit5/pom.xml
+++ b/examples/cucubmer7/cucumber7-maven-junit5/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aspectj.version>1.9.22</aspectj.version>
-        <qase.version>4.1.24</qase.version>
+        <qase.version>4.1.25</qase.version>
         <cucumber.version>7.14.0</cucumber.version>
     </properties>
 

--- a/examples/cucubmer7/cucumber7-maven-testng/pom.xml
+++ b/examples/cucubmer7/cucumber7-maven-testng/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aspectj.version>1.9.22</aspectj.version>
-        <qase.version>4.1.24</qase.version>
+        <qase.version>4.1.25</qase.version>
         <cucumber.version>7.14.0</cucumber.version>
     </properties>
 

--- a/examples/junit4/junit4-gradle/build.gradle
+++ b/examples/junit4/junit4-gradle/build.gradle
@@ -17,7 +17,7 @@ repositories {
 dependencies {
     testImplementation 'junit:junit:4.13.1'
     testImplementation "org.junit.platform:junit-platform-runner:1.6.3"
-    testImplementation("io.qase:qase-junit4-reporter:4.1.24")
+    testImplementation("io.qase:qase-junit4-reporter:4.1.25")
     aspectConfig "org.aspectj:aspectjweaver:1.9.22"
 }
 

--- a/examples/junit4/junit4-maven/pom.xml
+++ b/examples/junit4/junit4-maven/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aspectj.version>1.9.22</aspectj.version>
-        <qase.version>4.1.24</qase.version>
+        <qase.version>4.1.25</qase.version>
     </properties>
 
     <dependencies>

--- a/examples/junit5/junit5-bazel/WORKSPACE
+++ b/examples/junit5/junit5-bazel/WORKSPACE
@@ -19,7 +19,7 @@ maven_install(
         "org.junit.jupiter:junit-jupiter-params:5.11.2",
         "org.junit.jupiter:junit-jupiter-engine:5.11.2",
         "org.junit.platform:junit-platform-console-standalone:1.11.4",
-        "io.qase:qase-junit5-reporter:4.1.24",
+        "io.qase:qase-junit5-reporter:4.1.25",
         "org.aspectj:aspectjweaver:1.9.22",
         "org.aspectj:aspectjrt:1.9.22",
         "org.slf4j:slf4j-api:1.7.32"

--- a/examples/junit5/junit5-gradle/build.gradle
+++ b/examples/junit5/junit5-gradle/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-params'
     testImplementation 'org.junit.jupiter:junit-jupiter-engine'
     testImplementation 'org.junit.platform:junit-platform-launcher'
-    testImplementation('io.qase:qase-junit5-reporter:4.1.24')
+    testImplementation('io.qase:qase-junit5-reporter:4.1.25')
     aspectConfig "org.aspectj:aspectjweaver:1.9.22"
 }
 

--- a/examples/junit5/junit5-maven/pom.xml
+++ b/examples/junit5/junit5-maven/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aspectj.version>1.9.22</aspectj.version>
-        <qase.version>4.1.24</qase.version>
+        <qase.version>4.1.25</qase.version>
     </properties>
 
     <dependencies>

--- a/examples/kotlin/junit4/build.gradle.kts
+++ b/examples/kotlin/junit4/build.gradle.kts
@@ -22,7 +22,7 @@ tasks.withType<JavaCompile>().configureEach {
 dependencies {
     testImplementation(kotlin("test"))
     testImplementation("junit:junit:4.13.1")
-    testImplementation("io.qase:qase-junit4-reporter:4.1.24")
+    testImplementation("io.qase:qase-junit4-reporter:4.1.25")
     "aspectConfig"("org.aspectj:aspectjweaver:1.9.22")
 }
 

--- a/examples/kotlin/junit5/build.gradle.kts
+++ b/examples/kotlin/junit5/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.0")
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.10.0")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.10.0")
-    testImplementation("io.qase:qase-junit5-reporter:4.1.24")
+    testImplementation("io.qase:qase-junit5-reporter:4.1.25")
     "aspectConfig"("org.aspectj:aspectjweaver:1.9.22")
 }
 

--- a/examples/kotlin/testng/build.gradle.kts
+++ b/examples/kotlin/testng/build.gradle.kts
@@ -22,7 +22,7 @@ tasks.withType<JavaCompile>().configureEach {
 dependencies {
     testImplementation(kotlin("test"))
     testImplementation("org.testng:testng:7.5")
-    testImplementation("io.qase:qase-testng-reporter:4.1.24")
+    testImplementation("io.qase:qase-testng-reporter:4.1.25")
     "aspectConfig"("org.aspectj:aspectjweaver:1.9.22")
 }
 

--- a/examples/testng/testng-gradle/build.gradle
+++ b/examples/testng/testng-gradle/build.gradle
@@ -24,7 +24,7 @@ repositories {
 dependencies {
     testImplementation "org.aspectj:aspectjrt:1.9.22"
     testImplementation "org.testng:testng:7.5"
-    testImplementation 'io.qase:qase-testng-reporter:4.1.24'
+    testImplementation 'io.qase:qase-testng-reporter:4.1.25'
     aspectConfig "org.aspectj:aspectjweaver:1.9.22"
 }
 

--- a/examples/testng/testng-maven/pom.xml
+++ b/examples/testng/testng-maven/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aspectj.version>1.9.22</aspectj.version>
-        <qase.version>4.1.24</qase.version>
+        <qase.version>4.1.25</qase.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.qase</groupId>
     <artifactId>qase-java</artifactId>
     <packaging>pom</packaging>
-    <version>4.1.24</version>
+    <version>4.1.25</version>
     <modules>
         <module>qase-java-commons</module>
         <module>qase-api-client</module>

--- a/qase-api-client/docs/CustomFieldsApi.md
+++ b/qase-api-client/docs/CustomFieldsApi.md
@@ -5,10 +5,10 @@ All URIs are relative to *https://api.qase.io/v1*
 | Method | HTTP request | Description |
 |------------- | ------------- | -------------|
 | [**createCustomField**](CustomFieldsApi.md#createCustomField) | **POST** /custom_field | Create new Custom Field |
-| [**deleteCustomField**](CustomFieldsApi.md#deleteCustomField) | **DELETE** /custom_field/{id} | Delete Custom Field by id |
-| [**getCustomField**](CustomFieldsApi.md#getCustomField) | **GET** /custom_field/{id} | Get Custom Field by id |
+| [**deleteCustomField**](CustomFieldsApi.md#deleteCustomField) | **DELETE** /custom_field/{id} | Delete Custom Field |
+| [**getCustomField**](CustomFieldsApi.md#getCustomField) | **GET** /custom_field/{id} | Get Custom Field |
 | [**getCustomFields**](CustomFieldsApi.md#getCustomFields) | **GET** /custom_field | Get all Custom Fields |
-| [**updateCustomField**](CustomFieldsApi.md#updateCustomField) | **PATCH** /custom_field/{id} | Update Custom Field by id |
+| [**updateCustomField**](CustomFieldsApi.md#updateCustomField) | **PATCH** /custom_field/{id} | Update Custom Field |
 
 
 <a id="createCustomField"></a>
@@ -89,7 +89,7 @@ public class Example {
 # **deleteCustomField**
 > BaseResponse deleteCustomField(id)
 
-Delete Custom Field by id
+Delete Custom Field
 
 This method allows to delete custom field. 
 
@@ -163,7 +163,7 @@ public class Example {
 # **getCustomField**
 > CustomFieldResponse getCustomField(id)
 
-Get Custom Field by id
+Get Custom Field
 
 This method allows to retrieve custom field. 
 
@@ -316,7 +316,7 @@ public class Example {
 # **updateCustomField**
 > BaseResponse updateCustomField(id, customFieldUpdate)
 
-Update Custom Field by id
+Update Custom Field
 
 This method allows to update custom field. 
 

--- a/qase-api-client/pom.xml
+++ b/qase-api-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.24</version>
+        <version>4.1.25</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-api-client/src/main/java/io/qase/client/v1/api/AttachmentsApi.java
+++ b/qase-api-client/src/main/java/io/qase/client/v1/api/AttachmentsApi.java
@@ -574,7 +574,7 @@ public class AttachmentsApi {
         Map<String, Object> localVarFormParams = new HashMap<String, Object>();
 
         if (_file != null) {
-            localVarFormParams.put("file", _file);
+            localVarFormParams.put("file[]", _file);
         }
 
         final String[] localVarAccepts = {

--- a/qase-api-client/src/main/java/io/qase/client/v1/api/CustomFieldsApi.java
+++ b/qase-api-client/src/main/java/io/qase/client/v1/api/CustomFieldsApi.java
@@ -299,7 +299,7 @@ public class CustomFieldsApi {
     }
 
     /**
-     * Delete Custom Field by id
+     * Delete Custom Field
      * This method allows to delete custom field. 
      * @param id Identifier. (required)
      * @return BaseResponse
@@ -322,7 +322,7 @@ public class CustomFieldsApi {
     }
 
     /**
-     * Delete Custom Field by id
+     * Delete Custom Field
      * This method allows to delete custom field. 
      * @param id Identifier. (required)
      * @return ApiResponse&lt;BaseResponse&gt;
@@ -346,7 +346,7 @@ public class CustomFieldsApi {
     }
 
     /**
-     * Delete Custom Field by id (asynchronously)
+     * Delete Custom Field (asynchronously)
      * This method allows to delete custom field. 
      * @param id Identifier. (required)
      * @param _callback The callback to be executed when the API call finishes
@@ -446,7 +446,7 @@ public class CustomFieldsApi {
     }
 
     /**
-     * Get Custom Field by id
+     * Get Custom Field
      * This method allows to retrieve custom field. 
      * @param id Identifier. (required)
      * @return CustomFieldResponse
@@ -469,7 +469,7 @@ public class CustomFieldsApi {
     }
 
     /**
-     * Get Custom Field by id
+     * Get Custom Field
      * This method allows to retrieve custom field. 
      * @param id Identifier. (required)
      * @return ApiResponse&lt;CustomFieldResponse&gt;
@@ -493,7 +493,7 @@ public class CustomFieldsApi {
     }
 
     /**
-     * Get Custom Field by id (asynchronously)
+     * Get Custom Field (asynchronously)
      * This method allows to retrieve custom field. 
      * @param id Identifier. (required)
      * @param _callback The callback to be executed when the API call finishes
@@ -766,7 +766,7 @@ public class CustomFieldsApi {
     }
 
     /**
-     * Update Custom Field by id
+     * Update Custom Field
      * This method allows to update custom field. 
      * @param id Identifier. (required)
      * @param customFieldUpdate  (required)
@@ -791,7 +791,7 @@ public class CustomFieldsApi {
     }
 
     /**
-     * Update Custom Field by id
+     * Update Custom Field
      * This method allows to update custom field. 
      * @param id Identifier. (required)
      * @param customFieldUpdate  (required)
@@ -817,7 +817,7 @@ public class CustomFieldsApi {
     }
 
     /**
-     * Update Custom Field by id (asynchronously)
+     * Update Custom Field (asynchronously)
      * This method allows to update custom field. 
      * @param id Identifier. (required)
      * @param customFieldUpdate  (required)

--- a/qase-api-v2-client/pom.xml
+++ b/qase-api-v2-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.qase</groupId>
         <artifactId>qase-java</artifactId>
-        <version>4.1.24</version>
+        <version>4.1.25</version>
     </parent>
 
     <artifactId>qase-api-v2-client</artifactId>

--- a/qase-cucumber-v3-reporter/pom.xml
+++ b/qase-cucumber-v3-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.24</version>
+        <version>4.1.25</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v4-reporter/pom.xml
+++ b/qase-cucumber-v4-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.24</version>
+        <version>4.1.25</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v5-reporter/pom.xml
+++ b/qase-cucumber-v5-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.24</version>
+        <version>4.1.25</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v6-reporter/pom.xml
+++ b/qase-cucumber-v6-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.24</version>
+        <version>4.1.25</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v7-reporter/pom.xml
+++ b/qase-cucumber-v7-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.24</version>
+        <version>4.1.25</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-java-commons/pom.xml
+++ b/qase-java-commons/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.qase</groupId>
         <artifactId>qase-java</artifactId>
-        <version>4.1.24</version>
+        <version>4.1.25</version>
     </parent>
 
     <artifactId>qase-java-commons</artifactId>

--- a/qase-java-commons/src/main/java/io/qase/commons/client/ApiClientV2.java
+++ b/qase-java-commons/src/main/java/io/qase/commons/client/ApiClientV2.java
@@ -83,10 +83,7 @@ public class ApiClientV2 implements ApiClient {
     }
 
     private ResultCreate convertResult(TestResult result) {
-        List<String> attachments = result.attachments.stream()
-                .map(this.apiClientV1::uploadAttachment)
-                .filter(attachment -> !attachment.isEmpty())
-                .collect(Collectors.toList());
+        List<String> attachments = this.apiClientV1.uploadAttachments(result.attachments);
 
         List<ResultStep> steps = result.steps.stream()
                 .map(this::convertStepResult).collect(Collectors.toList());
@@ -174,10 +171,7 @@ public class ApiClientV2 implements ApiClient {
             data.inputData(step.data.inputData);
         }
 
-        List<String> attachments = step.attachments.stream()
-                .map(this.apiClientV1::uploadAttachment)
-                .filter(attachment -> !attachment.isEmpty())
-                .collect(Collectors.toList());
+        List<String> attachments = this.apiClientV1.uploadAttachments(step.attachments);
 
         ResultStepExecution execution = new ResultStepExecution()
                 .status(ResultStepStatus.fromValue(step.execution.status.toString().toLowerCase()))

--- a/qase-junit4-reporter/pom.xml
+++ b/qase-junit4-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.24</version>
+        <version>4.1.25</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-junit5-reporter/pom.xml
+++ b/qase-junit5-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.24</version>
+        <version>4.1.25</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-testng-reporter/pom.xml
+++ b/qase-testng-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.24</version>
+        <version>4.1.25</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
- Updated version number to 4.1.25 in all relevant pom.xml files.
- Enhanced the upload mechanism for attachments, allowing batch uploads of up to 20 files.
- Updated changelog to reflect the new version and changes made.