### PR TITLE
chore: update version to 4.1.26 across all modules

### DIFF
--- a/examples/cucubmer3/cucubmer3-gradle/build.gradle
+++ b/examples/cucubmer3/cucubmer3-gradle/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     testImplementation("io.cucumber:cucumber-core:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-java:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-testng:$cucumberVersion")
-    testImplementation("io.qase:qase-cucumber-v3-reporter:4.1.25")
+    testImplementation("io.qase:qase-cucumber-v3-reporter:4.1.26")
 }
 
 test {

--- a/examples/cucubmer3/cucumber3-maven/pom.xml
+++ b/examples/cucubmer3/cucumber3-maven/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aspectj.version>1.9.22</aspectj.version>
-        <qase.version>4.1.25</qase.version>
+        <qase.version>4.1.26</qase.version>
     </properties>
 
     <dependencies>

--- a/examples/cucubmer4/cucubmer4-gradle/build.gradle
+++ b/examples/cucubmer4/cucubmer4-gradle/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     testImplementation("io.cucumber:cucumber-core:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-java:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-testng:$cucumberVersion")
-    testImplementation("io.qase:qase-cucumber-v4-reporter:4.1.25")
+    testImplementation("io.qase:qase-cucumber-v4-reporter:4.1.26")
 }
 
 test {

--- a/examples/cucubmer4/cucumber4-maven/pom.xml
+++ b/examples/cucubmer4/cucumber4-maven/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aspectj.version>1.9.22</aspectj.version>
-        <qase.version>4.1.25</qase.version>
+        <qase.version>4.1.26</qase.version>
     </properties>
 
     <dependencies>

--- a/examples/cucubmer5/cucubmer5-gradle/build.gradle
+++ b/examples/cucubmer5/cucubmer5-gradle/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     testImplementation("io.cucumber:cucumber-core:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-java:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-testng:$cucumberVersion")
-    testImplementation("io.qase:qase-cucumber-v5-reporter:4.1.25")
+    testImplementation("io.qase:qase-cucumber-v5-reporter:4.1.26")
 }
 
 test {

--- a/examples/cucubmer5/cucumber5-maven/pom.xml
+++ b/examples/cucubmer5/cucumber5-maven/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aspectj.version>1.9.22</aspectj.version>
-        <qase.version>4.1.25</qase.version>
+        <qase.version>4.1.26</qase.version>
     </properties>
 
     <dependencies>

--- a/examples/cucubmer6/cucubmer6-gradle/build.gradle
+++ b/examples/cucubmer6/cucubmer6-gradle/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     testImplementation("io.cucumber:cucumber-core:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-java:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-testng:$cucumberVersion")
-    testImplementation("io.qase:qase-cucumber-v6-reporter:4.1.25")
+    testImplementation("io.qase:qase-cucumber-v6-reporter:4.1.26")
 }
 
 test {

--- a/examples/cucubmer6/cucumber6-maven/pom.xml
+++ b/examples/cucubmer6/cucumber6-maven/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aspectj.version>1.9.22</aspectj.version>
-        <qase.version>4.1.25</qase.version>
+        <qase.version>4.1.26</qase.version>
         <cucumber.version>6.11.0</cucumber.version>
     </properties>
 

--- a/examples/cucubmer7/cucumber7-gradle-junit4/build.gradle
+++ b/examples/cucubmer7/cucumber7-gradle-junit4/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     testImplementation("io.cucumber:cucumber-core:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-java:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-junit:$cucumberVersion")
-    testImplementation("io.qase:qase-cucumber-v7-reporter:4.1.25")
+    testImplementation("io.qase:qase-cucumber-v7-reporter:4.1.26")
 }
 
 test {

--- a/examples/cucubmer7/cucumber7-gradle-junit5/build.gradle
+++ b/examples/cucubmer7/cucumber7-gradle-junit5/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     testImplementation("io.cucumber:cucumber-core:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-java:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-junit-platform-engine:$cucumberVersion")
-    testImplementation("io.qase:qase-cucumber-v7-reporter:4.1.25")
+    testImplementation("io.qase:qase-cucumber-v7-reporter:4.1.26")
 }
 
 test {

--- a/examples/cucubmer7/cucumber7-gradle-testng/build.gradle
+++ b/examples/cucubmer7/cucumber7-gradle-testng/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     testImplementation("io.cucumber:cucumber-core:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-java:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-testng:$cucumberVersion")
-    testImplementation("io.qase:qase-cucumber-v7-reporter:4.1.25")
+    testImplementation("io.qase:qase-cucumber-v7-reporter:4.1.26")
 }
 
 test {

--- a/examples/cucubmer7/cucumber7-gradlekts-junit5/build.gradle.kts
+++ b/examples/cucubmer7/cucumber7-gradlekts-junit5/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
     testImplementation("io.cucumber:cucumber-core:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-java:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-junit-platform-engine:$cucumberVersion")
-    testImplementation("io.qase:qase-cucumber-v7-reporter:4.1.25")
+    testImplementation("io.qase:qase-cucumber-v7-reporter:4.1.26")
 }
 
 tasks.test {

--- a/examples/cucubmer7/cucumber7-maven-junit4/pom.xml
+++ b/examples/cucubmer7/cucumber7-maven-junit4/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aspectj.version>1.9.22</aspectj.version>
-        <qase.version>4.1.25</qase.version>
+        <qase.version>4.1.26</qase.version>
         <cucumber.version>7.14.0</cucumber.version>
     </properties>
 

--- a/examples/cucubmer7/cucumber7-maven-junit5/pom.xml
+++ b/examples/cucubmer7/cucumber7-maven-junit5/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aspectj.version>1.9.22</aspectj.version>
-        <qase.version>4.1.25</qase.version>
+        <qase.version>4.1.26</qase.version>
         <cucumber.version>7.14.0</cucumber.version>
     </properties>
 

--- a/examples/cucubmer7/cucumber7-maven-testng/pom.xml
+++ b/examples/cucubmer7/cucumber7-maven-testng/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aspectj.version>1.9.22</aspectj.version>
-        <qase.version>4.1.25</qase.version>
+        <qase.version>4.1.26</qase.version>
         <cucumber.version>7.14.0</cucumber.version>
     </properties>
 

--- a/examples/junit4/junit4-gradle/build.gradle
+++ b/examples/junit4/junit4-gradle/build.gradle
@@ -17,7 +17,7 @@ repositories {
 dependencies {
     testImplementation 'junit:junit:4.13.1'
     testImplementation "org.junit.platform:junit-platform-runner:1.6.3"
-    testImplementation("io.qase:qase-junit4-reporter:4.1.25")
+    testImplementation("io.qase:qase-junit4-reporter:4.1.26")
     aspectConfig "org.aspectj:aspectjweaver:1.9.22"
 }
 

--- a/examples/junit4/junit4-maven/pom.xml
+++ b/examples/junit4/junit4-maven/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aspectj.version>1.9.22</aspectj.version>
-        <qase.version>4.1.25</qase.version>
+        <qase.version>4.1.26</qase.version>
     </properties>
 
     <dependencies>

--- a/examples/junit5/junit5-bazel/WORKSPACE
+++ b/examples/junit5/junit5-bazel/WORKSPACE
@@ -19,7 +19,7 @@ maven_install(
         "org.junit.jupiter:junit-jupiter-params:5.11.2",
         "org.junit.jupiter:junit-jupiter-engine:5.11.2",
         "org.junit.platform:junit-platform-console-standalone:1.11.4",
-        "io.qase:qase-junit5-reporter:4.1.25",
+        "io.qase:qase-junit5-reporter:4.1.26",
         "org.aspectj:aspectjweaver:1.9.22",
         "org.aspectj:aspectjrt:1.9.22",
         "org.slf4j:slf4j-api:1.7.32"

--- a/examples/junit5/junit5-gradle/build.gradle
+++ b/examples/junit5/junit5-gradle/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-params'
     testImplementation 'org.junit.jupiter:junit-jupiter-engine'
     testImplementation 'org.junit.platform:junit-platform-launcher'
-    testImplementation('io.qase:qase-junit5-reporter:4.1.25')
+    testImplementation('io.qase:qase-junit5-reporter:4.1.26')
     aspectConfig "org.aspectj:aspectjweaver:1.9.22"
 }
 

--- a/examples/junit5/junit5-maven/pom.xml
+++ b/examples/junit5/junit5-maven/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aspectj.version>1.9.22</aspectj.version>
-        <qase.version>4.1.25</qase.version>
+        <qase.version>4.1.26</qase.version>
     </properties>
 
     <dependencies>

--- a/examples/kotlin/junit4/build.gradle.kts
+++ b/examples/kotlin/junit4/build.gradle.kts
@@ -22,7 +22,7 @@ tasks.withType<JavaCompile>().configureEach {
 dependencies {
     testImplementation(kotlin("test"))
     testImplementation("junit:junit:4.13.1")
-    testImplementation("io.qase:qase-junit4-reporter:4.1.25")
+    testImplementation("io.qase:qase-junit4-reporter:4.1.26")
     "aspectConfig"("org.aspectj:aspectjweaver:1.9.22")
 }
 

--- a/examples/kotlin/junit5/build.gradle.kts
+++ b/examples/kotlin/junit5/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.0")
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.10.0")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.10.0")
-    testImplementation("io.qase:qase-junit5-reporter:4.1.25")
+    testImplementation("io.qase:qase-junit5-reporter:4.1.26")
     "aspectConfig"("org.aspectj:aspectjweaver:1.9.22")
 }
 

--- a/examples/kotlin/testng/build.gradle.kts
+++ b/examples/kotlin/testng/build.gradle.kts
@@ -22,7 +22,7 @@ tasks.withType<JavaCompile>().configureEach {
 dependencies {
     testImplementation(kotlin("test"))
     testImplementation("org.testng:testng:7.5")
-    testImplementation("io.qase:qase-testng-reporter:4.1.25")
+    testImplementation("io.qase:qase-testng-reporter:4.1.26")
     "aspectConfig"("org.aspectj:aspectjweaver:1.9.22")
 }
 

--- a/examples/testng/testng-gradle/build.gradle
+++ b/examples/testng/testng-gradle/build.gradle
@@ -24,7 +24,7 @@ repositories {
 dependencies {
     testImplementation "org.aspectj:aspectjrt:1.9.22"
     testImplementation "org.testng:testng:7.5"
-    testImplementation 'io.qase:qase-testng-reporter:4.1.25'
+    testImplementation 'io.qase:qase-testng-reporter:4.1.26'
     aspectConfig "org.aspectj:aspectjweaver:1.9.22"
 }
 

--- a/examples/testng/testng-maven/pom.xml
+++ b/examples/testng/testng-maven/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aspectj.version>1.9.22</aspectj.version>
-        <qase.version>4.1.25</qase.version>
+        <qase.version>4.1.26</qase.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.qase</groupId>
     <artifactId>qase-java</artifactId>
     <packaging>pom</packaging>
-    <version>4.1.25</version>
+    <version>4.1.26</version>
     <modules>
         <module>qase-java-commons</module>
         <module>qase-api-client</module>

--- a/qase-api-client/pom.xml
+++ b/qase-api-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.25</version>
+        <version>4.1.26</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-api-v2-client/pom.xml
+++ b/qase-api-v2-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.qase</groupId>
         <artifactId>qase-java</artifactId>
-        <version>4.1.25</version>
+        <version>4.1.26</version>
     </parent>
 
     <artifactId>qase-api-v2-client</artifactId>

--- a/qase-cucumber-v3-reporter/pom.xml
+++ b/qase-cucumber-v3-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.25</version>
+        <version>4.1.26</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v3-reporter/src/main/java/io/qase/cucumber3/QaseEventListener.java
+++ b/qase-cucumber-v3-reporter/src/main/java/io/qase/cucumber3/QaseEventListener.java
@@ -33,8 +33,27 @@ public class QaseEventListener implements Formatter {
     private final ScenarioStorage scenarioStorage;
 
     public QaseEventListener() {
-        this.qaseTestCaseListener = CoreReporterFactory.getInstance();
+        String reporterVersion = QaseEventListener.class.getPackage().getImplementationVersion();
+        String frameworkVersion = getFrameworkVersion();
+        this.qaseTestCaseListener = CoreReporterFactory.getInstance(
+            "qase-cucumber-v3", reporterVersion, "cucumber", frameworkVersion);
         this.scenarioStorage = new ScenarioStorage();
+    }
+
+    private String getFrameworkVersion() {
+        try {
+            Package pkg = cucumber.api.TestCase.class.getPackage();
+            if (pkg != null) {
+                String version = pkg.getImplementationVersion();
+                if (version == null || version.isEmpty()) {
+                    version = pkg.getSpecificationVersion();
+                }
+                return version != null ? version : "";
+            }
+        } catch (Exception e) {
+            // Framework version not available
+        }
+        return "";
     }
 
     @Override

--- a/qase-cucumber-v4-reporter/pom.xml
+++ b/qase-cucumber-v4-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.25</version>
+        <version>4.1.26</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v4-reporter/src/main/java/io/qase/cucumber4/QaseEventListener.java
+++ b/qase-cucumber-v4-reporter/src/main/java/io/qase/cucumber4/QaseEventListener.java
@@ -32,8 +32,27 @@ public class QaseEventListener implements ConcurrentEventListener {
     private final ScenarioStorage scenarioStorage;
 
     public QaseEventListener() {
-        this.qaseTestCaseListener = CoreReporterFactory.getInstance();
+        String reporterVersion = QaseEventListener.class.getPackage().getImplementationVersion();
+        String frameworkVersion = getFrameworkVersion();
+        this.qaseTestCaseListener = CoreReporterFactory.getInstance(
+            "qase-cucumber-v4", reporterVersion, "cucumber", frameworkVersion);
         this.scenarioStorage = new ScenarioStorage();
+    }
+
+    private String getFrameworkVersion() {
+        try {
+            Package pkg = cucumber.api.TestCase.class.getPackage();
+            if (pkg != null) {
+                String version = pkg.getImplementationVersion();
+                if (version == null || version.isEmpty()) {
+                    version = pkg.getSpecificationVersion();
+                }
+                return version != null ? version : "";
+            }
+        } catch (Exception e) {
+            // Framework version not available
+        }
+        return "";
     }
 
     @Override

--- a/qase-cucumber-v5-reporter/pom.xml
+++ b/qase-cucumber-v5-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.25</version>
+        <version>4.1.26</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v5-reporter/src/main/java/io/qase/cucumber5/QaseEventListener.java
+++ b/qase-cucumber-v5-reporter/src/main/java/io/qase/cucumber5/QaseEventListener.java
@@ -24,8 +24,27 @@ public class QaseEventListener implements ConcurrentEventListener {
     private final ScenarioStorage scenarioStorage;
 
     public QaseEventListener() {
-        this.qaseTestCaseListener = CoreReporterFactory.getInstance();
+        String reporterVersion = QaseEventListener.class.getPackage().getImplementationVersion();
+        String frameworkVersion = getFrameworkVersion();
+        this.qaseTestCaseListener = CoreReporterFactory.getInstance(
+            "qase-cucumber-v5", reporterVersion, "cucumber", frameworkVersion);
         this.scenarioStorage = new ScenarioStorage();
+    }
+
+    private String getFrameworkVersion() {
+        try {
+            Package pkg = io.cucumber.plugin.event.TestCase.class.getPackage();
+            if (pkg != null) {
+                String version = pkg.getImplementationVersion();
+                if (version == null || version.isEmpty()) {
+                    version = pkg.getSpecificationVersion();
+                }
+                return version != null ? version : "";
+            }
+        } catch (Exception e) {
+            // Framework version not available
+        }
+        return "";
     }
 
     @Override

--- a/qase-cucumber-v6-reporter/pom.xml
+++ b/qase-cucumber-v6-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.25</version>
+        <version>4.1.26</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v6-reporter/src/main/java/io/qase/cucumber6/QaseEventListener.java
+++ b/qase-cucumber-v6-reporter/src/main/java/io/qase/cucumber6/QaseEventListener.java
@@ -31,8 +31,27 @@ public class QaseEventListener implements ConcurrentEventListener {
     private final ThreadLocal<URI> currentFeatureFile = new InheritableThreadLocal<>();
 
     public QaseEventListener() {
-        this.qaseTestCaseListener = CoreReporterFactory.getInstance();
+        String reporterVersion = QaseEventListener.class.getPackage().getImplementationVersion();
+        String frameworkVersion = getFrameworkVersion();
+        this.qaseTestCaseListener = CoreReporterFactory.getInstance(
+            "qase-cucumber-v6", reporterVersion, "cucumber", frameworkVersion);
         this.scenarioStorage = new ScenarioStorage();
+    }
+
+    private String getFrameworkVersion() {
+        try {
+            Package pkg = io.cucumber.plugin.event.TestCase.class.getPackage();
+            if (pkg != null) {
+                String version = pkg.getImplementationVersion();
+                if (version == null || version.isEmpty()) {
+                    version = pkg.getSpecificationVersion();
+                }
+                return version != null ? version : "";
+            }
+        } catch (Exception e) {
+            // Framework version not available
+        }
+        return "";
     }
 
     @Override

--- a/qase-cucumber-v7-reporter/pom.xml
+++ b/qase-cucumber-v7-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.25</version>
+        <version>4.1.26</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v7-reporter/src/main/java/io/qase/cucumber7/QaseEventListener.java
+++ b/qase-cucumber-v7-reporter/src/main/java/io/qase/cucumber7/QaseEventListener.java
@@ -35,8 +35,27 @@ public class QaseEventListener implements ConcurrentEventListener {
     private final ThreadLocal<URI> currentFeatureFile = new InheritableThreadLocal<>();
 
     public QaseEventListener() {
-        this.qaseTestCaseListener = CoreReporterFactory.getInstance();
+        String reporterVersion = QaseEventListener.class.getPackage().getImplementationVersion();
+        String frameworkVersion = getFrameworkVersion();
+        this.qaseTestCaseListener = CoreReporterFactory.getInstance(
+            "qase-cucumber-v7", reporterVersion, "cucumber", frameworkVersion);
         this.scenarioStorage = new ScenarioStorage();
+    }
+
+    private String getFrameworkVersion() {
+        try {
+            Package pkg = io.cucumber.plugin.event.TestCase.class.getPackage();
+            if (pkg != null) {
+                String version = pkg.getImplementationVersion();
+                if (version == null || version.isEmpty()) {
+                    version = pkg.getSpecificationVersion();
+                }
+                return version != null ? version : "";
+            }
+        } catch (Throwable e) {
+            // Framework version not available
+        }
+        return "";
     }
 
     @Override

--- a/qase-java-commons/pom.xml
+++ b/qase-java-commons/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.qase</groupId>
         <artifactId>qase-java</artifactId>
-        <version>4.1.25</version>
+        <version>4.1.26</version>
     </parent>
 
     <artifactId>qase-java-commons</artifactId>

--- a/qase-java-commons/src/main/java/io/qase/commons/reporters/CoreReporter.java
+++ b/qase-java-commons/src/main/java/io/qase/commons/reporters/CoreReporter.java
@@ -15,6 +15,7 @@ import io.qase.commons.writers.Writer;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 
 public class CoreReporter implements Reporter {
@@ -24,9 +25,24 @@ public class CoreReporter implements Reporter {
     private InternalReporter fallback;
     private final HooksManager hooksManager;
     private final QaseConfig config;
+    private final String reporterName;
+    private final String reporterVersion;
+    private final String frameworkName;
+    private final String frameworkVersion;
+    private final java.util.Map<String, String> hostInfo;
 
     public CoreReporter(QaseConfig config) {
+        this(config, null, null, null, null, null);
+    }
+
+    public CoreReporter(QaseConfig config, String reporterName, String reporterVersion,
+                       String frameworkName, String frameworkVersion, java.util.Map<String, String> hostInfo) {
         this.config = config;
+        this.reporterName = reporterName;
+        this.reporterVersion = reporterVersion;
+        this.frameworkName = frameworkName;
+        this.frameworkVersion = frameworkVersion;
+        this.hostInfo = hostInfo;
         this.reporter = this.createReporter(config, config.mode);
         this.fallback = this.createReporter(config, config.fallback);
         this.hooksManager = HooksManager.getDefaultHooksManager();
@@ -142,7 +158,7 @@ public class CoreReporter implements Reporter {
     private InternalReporter createReporter(QaseConfig config, Mode mode) {
         switch (mode) {
             case TESTOPS:
-                ApiClient client = new ApiClientV2(config);
+                ApiClient client = new ApiClientV2(config, reporterName, reporterVersion, frameworkName, frameworkVersion, hostInfo);
                 return new TestopsReporter(config.testops, client);
             case REPORT:
                 Writer writer = new FileWriter(config.report.connection);

--- a/qase-java-commons/src/main/java/io/qase/commons/reporters/CoreReporterFactory.java
+++ b/qase-java-commons/src/main/java/io/qase/commons/reporters/CoreReporterFactory.java
@@ -16,6 +16,11 @@ public class CoreReporterFactory {
     }
 
     public static synchronized CoreReporter getInstance() {
+        return getInstance(null, null, null, null);
+    }
+
+    public static synchronized CoreReporter getInstance(String reporterName, String reporterVersion,
+                                                        String frameworkName, String frameworkVersion) {
         if (instance == null) {
             QaseConfig config = ConfigFactory.loadConfig();
             
@@ -30,9 +35,10 @@ public class CoreReporterFactory {
             
             logger.debug("Qase config: %s", config);
             HostInfo hostInfoCollector = new HostInfo();
-            Map<String, String> hostInfo = hostInfoCollector.getHostInfo(CoreReporterFactory.class.getPackage().getImplementationVersion());
+            Map<String, String> hostInfo = hostInfoCollector.getHostInfo(
+                reporterVersion != null ? reporterVersion : CoreReporterFactory.class.getPackage().getImplementationVersion());
             logger.debug("Using host info: %s", hostInfo.toString());
-            instance = new CoreReporter(config);
+            instance = new CoreReporter(config, reporterName, reporterVersion, frameworkName, frameworkVersion, hostInfo);
         }
         return instance;
     }

--- a/qase-java-commons/src/main/java/io/qase/commons/utils/ClientHeadersBuilder.java
+++ b/qase-java-commons/src/main/java/io/qase/commons/utils/ClientHeadersBuilder.java
@@ -1,0 +1,303 @@
+package io.qase.commons.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Utility class for building X-Client and X-Platform headers for API requests
+ */
+public class ClientHeadersBuilder {
+    
+    /**
+     * Build X-Client header value
+     * Format: reporter={reporter_name};reporter_version=v{reporter_version};framework={framework};framework_version={framework_version};client_version_v1=v{api_client_v1_version};client_version_v2=v{api_client_v2_version};core_version=v{commons_version}
+     * 
+     * @return X-Client header value
+     */
+    public static String buildXClientHeader() {
+        return buildXClientHeader(null, null, null, null);
+    }
+    
+    /**
+     * Build X-Client header value
+     * Format: reporter={reporter_name};reporter_version=v{reporter_version};framework={framework};framework_version={framework_version};client_version_v1=v{api_client_v1_version};client_version_v2=v{api_client_v2_version};core_version=v{commons_version}
+     * 
+     * @param reporterName Reporter name (e.g., "qase-junit5")
+     * @param reporterVersion Reporter version
+     * @param frameworkName Framework name (e.g., "junit5", "testng", "cucumber")
+     * @param frameworkVersion Framework version
+     * @return X-Client header value
+     */
+    public static String buildXClientHeader(String reporterName, String reporterVersion,
+                                            String frameworkName, String frameworkVersion) {
+        List<String> parts = new ArrayList<>();
+        
+        // Get package versions
+        String apiClientV1Version = getPackageVersion("io.qase.client.v1.ApiClient");
+        String apiClientV2Version = getPackageVersion("io.qase.client.v2.ApiClient");
+        String commonsVersion = getPackageVersion("io.qase.commons.utils.ClientHeadersBuilder");
+        
+        // Try to detect reporter and framework from stack trace if not provided
+        if (reporterName == null || reporterName.isEmpty()) {
+            ReporterInfo detected = detectReporterAndFramework();
+            if (detected != null) {
+                reporterName = detected.reporterName;
+                reporterVersion = detected.reporterVersion;
+                frameworkName = detected.frameworkName;
+                frameworkVersion = detected.frameworkVersion;
+            }
+        }
+        
+        // Add reporter info
+        if (reporterName != null && !reporterName.isEmpty()) {
+            parts.add("reporter=" + reporterName);
+        }
+        if (reporterVersion != null && !reporterVersion.isEmpty()) {
+            parts.add("reporter_version=v" + ensureNoVPrefix(reporterVersion));
+        }
+        
+        // Add framework info
+        if (frameworkName != null && !frameworkName.isEmpty()) {
+            parts.add("framework=" + frameworkName);
+        }
+        if (frameworkVersion != null && !frameworkVersion.isEmpty()) {
+            parts.add("framework_version=" + frameworkVersion);
+        }
+        
+        // Add client versions
+        if (apiClientV1Version != null && !apiClientV1Version.isEmpty()) {
+            parts.add("client_version_v1=v" + ensureNoVPrefix(apiClientV1Version));
+        }
+        if (apiClientV2Version != null && !apiClientV2Version.isEmpty()) {
+            parts.add("client_version_v2=v" + ensureNoVPrefix(apiClientV2Version));
+        }
+        
+        // Add core version
+        if (commonsVersion != null && !commonsVersion.isEmpty()) {
+            parts.add("core_version=v" + ensureNoVPrefix(commonsVersion));
+        }
+        
+        return String.join(";", parts);
+    }
+    
+    /**
+     * Build X-Platform header value
+     * Format: os={os_name};arch={arch};{language}={language_version};{package_manager}={package_manager_version}
+     * 
+     * @param hostInfo Host information map from HostInfo.getHostInfo()
+     * @return X-Platform header value
+     */
+    public static String buildXPlatformHeader(Map<String, String> hostInfo) {
+        List<String> parts = new ArrayList<>();
+        
+        if (hostInfo == null) {
+            return "";
+        }
+        
+        // OS name
+        String osName = hostInfo.get("system");
+        if (osName != null && !osName.isEmpty()) {
+            parts.add("os=" + osName);
+        }
+        
+        // Architecture
+        String arch = hostInfo.get("arch");
+        if (arch != null && !arch.isEmpty()) {
+            parts.add("arch=" + arch);
+        }
+        
+        // Java version (language)
+        String javaVersion = hostInfo.get("java");
+        if (javaVersion != null && !javaVersion.isEmpty()) {
+            parts.add("java=" + javaVersion);
+        }
+        
+        // Build tool version (package manager: maven or gradle)
+        String buildTool = hostInfo.get("buildTool");
+        if (buildTool != null && !buildTool.isEmpty()) {
+            // Determine package manager type
+            String packageManager = detectPackageManager();
+            // If package manager not detected but buildTool is present, default to maven
+            if (packageManager == null || packageManager.isEmpty()) {
+                packageManager = "maven"; // Default to maven if buildTool is present
+            }
+            parts.add(packageManager + "=" + buildTool);
+        }
+        
+        return String.join(";", parts);
+    }
+    
+    /**
+     * Get package implementation version
+     * 
+     * @param className Fully qualified class name
+     * @return Package version or null if not available
+     */
+    private static String getPackageVersion(String className) {
+        try {
+            Class<?> clazz = Class.forName(className);
+            Package pkg = clazz.getPackage();
+            if (pkg != null) {
+                String version = pkg.getImplementationVersion();
+                return version != null ? version : "";
+            }
+        } catch (ClassNotFoundException e) {
+            // Class not found, return empty string
+        }
+        return "";
+    }
+    
+    /**
+     * Ensure version string doesn't have duplicate "v" prefix
+     * 
+     * @param version Version string
+     * @return Version string without leading "v"
+     */
+    private static String ensureNoVPrefix(String version) {
+        if (version == null || version.isEmpty()) {
+            return version;
+        }
+        return version.startsWith("v") ? version.substring(1) : version;
+    }
+    
+    /**
+     * Detect package manager type (maven or gradle)
+     * 
+     * @return Package manager name or null if not detected
+     */
+    private static String detectPackageManager() {
+        // Check for Maven
+        try {
+            Class.forName("org.apache.maven.project.MavenProject");
+            return "maven";
+        } catch (ClassNotFoundException e) {
+            // Maven not found
+        }
+        
+        // Check for Gradle
+        try {
+            Class.forName("org.gradle.api.Project");
+            return "gradle";
+        } catch (ClassNotFoundException e) {
+            // Gradle not found
+        }
+        
+        // Try to detect from system properties or environment
+        String mavenHome = System.getProperty("maven.home");
+        if (mavenHome != null && !mavenHome.isEmpty()) {
+            return "maven";
+        }
+        
+        String gradleHome = System.getProperty("gradle.home");
+        if (gradleHome != null && !gradleHome.isEmpty()) {
+            return "gradle";
+        }
+        
+        // Default to maven if buildTool is present (most common)
+        return null;
+    }
+    
+    /**
+     * Detect reporter and framework from stack trace
+     * 
+     * @return ReporterInfo with detected information or null if not detected
+     */
+    private static ReporterInfo detectReporterAndFramework() {
+        try {
+            StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
+            for (StackTraceElement element : stackTrace) {
+                String className = element.getClassName();
+                
+                // Check for Qase reporter packages
+                if (className.startsWith("io.qase.")) {
+                    ReporterInfo info = new ReporterInfo();
+                    
+                    // Detect reporter name and version
+                    if (className.contains("junit4")) {
+                        info.reporterName = "qase-junit4";
+                        info.frameworkName = "junit4";
+                        info.reporterVersion = getPackageVersion("io.qase.junit4.QaseListener");
+                        info.frameworkVersion = getFrameworkVersion("junit.framework.TestCase");
+                    } else if (className.contains("junit5")) {
+                        info.reporterName = "qase-junit5";
+                        info.frameworkName = "junit5";
+                        info.reporterVersion = getPackageVersion("io.qase.junit5.QaseListener");
+                        info.frameworkVersion = getFrameworkVersion("org.junit.jupiter.api.Test");
+                    } else if (className.contains("testng")) {
+                        info.reporterName = "qase-testng";
+                        info.frameworkName = "testng";
+                        info.reporterVersion = getPackageVersion("io.qase.testng.QaseListener");
+                        info.frameworkVersion = getFrameworkVersion("org.testng.TestNG");
+                    } else if (className.contains("cucumber3")) {
+                        info.reporterName = "qase-cucumber-v3";
+                        info.frameworkName = "cucumber";
+                        info.reporterVersion = getPackageVersion("io.qase.cucumber3.QaseEventListener");
+                        info.frameworkVersion = getFrameworkVersion("io.cucumber.core.api.plugin.Plugin");
+                    } else if (className.contains("cucumber4")) {
+                        info.reporterName = "qase-cucumber-v4";
+                        info.frameworkName = "cucumber";
+                        info.reporterVersion = getPackageVersion("io.qase.cucumber4.QaseEventListener");
+                        info.frameworkVersion = getFrameworkVersion("io.cucumber.core.api.plugin.Plugin");
+                    } else if (className.contains("cucumber5")) {
+                        info.reporterName = "qase-cucumber-v5";
+                        info.frameworkName = "cucumber";
+                        info.reporterVersion = getPackageVersion("io.qase.cucumber5.QaseEventListener");
+                        info.frameworkVersion = getFrameworkVersion("io.cucumber.core.api.plugin.Plugin");
+                    } else if (className.contains("cucumber6")) {
+                        info.reporterName = "qase-cucumber-v6";
+                        info.frameworkName = "cucumber";
+                        info.reporterVersion = getPackageVersion("io.qase.cucumber6.QaseEventListener");
+                        info.frameworkVersion = getFrameworkVersion("io.cucumber.core.api.plugin.Plugin");
+                    } else if (className.contains("cucumber7")) {
+                        info.reporterName = "qase-cucumber-v7";
+                        info.frameworkName = "cucumber";
+                        info.reporterVersion = getPackageVersion("io.qase.cucumber7.QaseEventListener");
+                        info.frameworkVersion = getFrameworkVersion("io.cucumber.core.api.plugin.Plugin");
+                    }
+                    
+                    if (info.reporterName != null) {
+                        return info;
+                    }
+                }
+            }
+        } catch (Exception e) {
+            // If detection fails, return null (will skip reporter/framework info)
+        }
+        
+        return null;
+    }
+    
+    /**
+     * Get framework version from package
+     * 
+     * @param className Framework class name
+     * @return Framework version or empty string if not available
+     */
+    private static String getFrameworkVersion(String className) {
+        try {
+            Class<?> clazz = Class.forName(className);
+            Package pkg = clazz.getPackage();
+            if (pkg != null) {
+                String version = pkg.getImplementationVersion();
+                if (version == null || version.isEmpty()) {
+                    version = pkg.getSpecificationVersion();
+                }
+                return version != null ? version : "";
+            }
+        } catch (ClassNotFoundException e) {
+            // Framework class not found
+        }
+        return "";
+    }
+    
+    /**
+     * Internal class to hold reporter and framework information
+     */
+    private static class ReporterInfo {
+        String reporterName;
+        String reporterVersion;
+        String frameworkName;
+        String frameworkVersion;
+    }
+}

--- a/qase-junit4-reporter/pom.xml
+++ b/qase-junit4-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.25</version>
+        <version>4.1.26</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-junit4-reporter/src/main/java/io/qase/junit4/QaseListener.java
+++ b/qase-junit4-reporter/src/main/java/io/qase/junit4/QaseListener.java
@@ -26,7 +26,26 @@ public class QaseListener extends RunListener {
     private final Reporter qaseTestCaseListener;
 
     public QaseListener() {
-        this.qaseTestCaseListener = CoreReporterFactory.getInstance();
+        String reporterVersion = QaseListener.class.getPackage().getImplementationVersion();
+        String frameworkVersion = getFrameworkVersion();
+        this.qaseTestCaseListener = CoreReporterFactory.getInstance(
+            "qase-junit4", reporterVersion, "junit4", frameworkVersion);
+    }
+
+    private String getFrameworkVersion() {
+        try {
+            Package pkg = junit.framework.TestCase.class.getPackage();
+            if (pkg != null) {
+                String version = pkg.getImplementationVersion();
+                if (version == null || version.isEmpty()) {
+                    version = pkg.getSpecificationVersion();
+                }
+                return version != null ? version : "";
+            }
+        } catch (Exception e) {
+            // Framework version not available
+        }
+        return "";
     }
 
     @Override

--- a/qase-junit5-reporter/pom.xml
+++ b/qase-junit5-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.25</version>
+        <version>4.1.26</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-junit5-reporter/src/main/java/io/qase/junit5/Junit5PostDiscoveryFilter.java
+++ b/qase-junit5-reporter/src/main/java/io/qase/junit5/Junit5PostDiscoveryFilter.java
@@ -16,6 +16,8 @@ public class Junit5PostDiscoveryFilter implements PostDiscoveryFilter {
     private final List<Long> caseIds;
 
     public Junit5PostDiscoveryFilter() {
+        // Use getInstance() without parameters - instance should already be created by QaseListener
+        // with proper reporter and framework info
         this.caseIds = CoreReporterFactory.getInstance().getTestCaseIdsForExecution();
     }
 

--- a/qase-junit5-reporter/src/main/java/io/qase/junit5/QaseListener.java
+++ b/qase-junit5-reporter/src/main/java/io/qase/junit5/QaseListener.java
@@ -23,7 +23,26 @@ public class QaseListener implements TestExecutionListener, Extension, BeforeAll
 
 
     public QaseListener() {
-        this.qaseTestCaseListener = CoreReporterFactory.getInstance();
+        String reporterVersion = QaseListener.class.getPackage().getImplementationVersion();
+        String frameworkVersion = getFrameworkVersion();
+        this.qaseTestCaseListener = CoreReporterFactory.getInstance(
+            "qase-junit5", reporterVersion, "junit5", frameworkVersion);
+    }
+
+    private String getFrameworkVersion() {
+        try {
+            Package pkg = org.junit.jupiter.api.Test.class.getPackage();
+            if (pkg != null) {
+                String version = pkg.getImplementationVersion();
+                if (version == null || version.isEmpty()) {
+                    version = pkg.getSpecificationVersion();
+                }
+                return version != null ? version : "";
+            }
+        } catch (Exception e) {
+            // Framework version not available
+        }
+        return "";
     }
 
     @Override

--- a/qase-testng-reporter/pom.xml
+++ b/qase-testng-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.25</version>
+        <version>4.1.26</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-testng-reporter/src/main/java/io/qase/testng/QaseListener.java
+++ b/qase-testng-reporter/src/main/java/io/qase/testng/QaseListener.java
@@ -27,7 +27,26 @@ public class QaseListener implements ISuiteListener,
     private final io.qase.commons.reporters.Reporter qaseTestCaseListener;
 
     public QaseListener() {
-        this.qaseTestCaseListener = CoreReporterFactory.getInstance();
+        String reporterVersion = QaseListener.class.getPackage().getImplementationVersion();
+        String frameworkVersion = getFrameworkVersion();
+        this.qaseTestCaseListener = CoreReporterFactory.getInstance(
+            "qase-testng", reporterVersion, "testng", frameworkVersion);
+    }
+
+    private String getFrameworkVersion() {
+        try {
+            Package pkg = org.testng.TestNG.class.getPackage();
+            if (pkg != null) {
+                String version = pkg.getImplementationVersion();
+                if (version == null || version.isEmpty()) {
+                    version = pkg.getSpecificationVersion();
+                }
+                return version != null ? version : "";
+            }
+        } catch (Exception e) {
+            // Framework version not available
+        }
+        return "";
     }
 
     @Override


### PR DESCRIPTION
- Updated version number to 4.1.26 in all relevant pom.xml and build.gradle files.
- Enhanced QaseEventListener classes to include framework version detection for better reporting.
- Introduced ClientHeadersBuilder utility for constructing API request headers with reporter and framework information.
- Updated changelog to reflect the new version and changes made.