### PR TITLE
chore: update version to 4.1.27 across all modules

### DIFF
--- a/examples/cucubmer3/cucubmer3-gradle/build.gradle
+++ b/examples/cucubmer3/cucubmer3-gradle/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     testImplementation("io.cucumber:cucumber-core:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-java:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-testng:$cucumberVersion")
-    testImplementation("io.qase:qase-cucumber-v3-reporter:4.1.26")
+    testImplementation("io.qase:qase-cucumber-v3-reporter:4.1.27")
 }
 
 test {

--- a/examples/cucubmer3/cucumber3-maven/pom.xml
+++ b/examples/cucubmer3/cucumber3-maven/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aspectj.version>1.9.22</aspectj.version>
-        <qase.version>4.1.26</qase.version>
+        <qase.version>4.1.27</qase.version>
     </properties>
 
     <dependencies>

--- a/examples/cucubmer4/cucubmer4-gradle/build.gradle
+++ b/examples/cucubmer4/cucubmer4-gradle/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     testImplementation("io.cucumber:cucumber-core:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-java:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-testng:$cucumberVersion")
-    testImplementation("io.qase:qase-cucumber-v4-reporter:4.1.26")
+    testImplementation("io.qase:qase-cucumber-v4-reporter:4.1.27")
 }
 
 test {

--- a/examples/cucubmer4/cucumber4-maven/pom.xml
+++ b/examples/cucubmer4/cucumber4-maven/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aspectj.version>1.9.22</aspectj.version>
-        <qase.version>4.1.26</qase.version>
+        <qase.version>4.1.27</qase.version>
     </properties>
 
     <dependencies>

--- a/examples/cucubmer5/cucubmer5-gradle/build.gradle
+++ b/examples/cucubmer5/cucubmer5-gradle/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     testImplementation("io.cucumber:cucumber-core:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-java:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-testng:$cucumberVersion")
-    testImplementation("io.qase:qase-cucumber-v5-reporter:4.1.26")
+    testImplementation("io.qase:qase-cucumber-v5-reporter:4.1.27")
 }
 
 test {

--- a/examples/cucubmer5/cucumber5-maven/pom.xml
+++ b/examples/cucubmer5/cucumber5-maven/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aspectj.version>1.9.22</aspectj.version>
-        <qase.version>4.1.26</qase.version>
+        <qase.version>4.1.27</qase.version>
     </properties>
 
     <dependencies>

--- a/examples/cucubmer6/cucubmer6-gradle/build.gradle
+++ b/examples/cucubmer6/cucubmer6-gradle/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     testImplementation("io.cucumber:cucumber-core:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-java:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-testng:$cucumberVersion")
-    testImplementation("io.qase:qase-cucumber-v6-reporter:4.1.26")
+    testImplementation("io.qase:qase-cucumber-v6-reporter:4.1.27")
 }
 
 test {

--- a/examples/cucubmer6/cucumber6-maven/pom.xml
+++ b/examples/cucubmer6/cucumber6-maven/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aspectj.version>1.9.22</aspectj.version>
-        <qase.version>4.1.26</qase.version>
+        <qase.version>4.1.27</qase.version>
         <cucumber.version>6.11.0</cucumber.version>
     </properties>
 

--- a/examples/cucubmer7/cucumber7-gradle-junit4/build.gradle
+++ b/examples/cucubmer7/cucumber7-gradle-junit4/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     testImplementation("io.cucumber:cucumber-core:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-java:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-junit:$cucumberVersion")
-    testImplementation("io.qase:qase-cucumber-v7-reporter:4.1.26")
+    testImplementation("io.qase:qase-cucumber-v7-reporter:4.1.27")
 }
 
 test {

--- a/examples/cucubmer7/cucumber7-gradle-junit5/build.gradle
+++ b/examples/cucubmer7/cucumber7-gradle-junit5/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     testImplementation("io.cucumber:cucumber-core:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-java:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-junit-platform-engine:$cucumberVersion")
-    testImplementation("io.qase:qase-cucumber-v7-reporter:4.1.26")
+    testImplementation("io.qase:qase-cucumber-v7-reporter:4.1.27")
 }
 
 test {

--- a/examples/cucubmer7/cucumber7-gradle-testng/build.gradle
+++ b/examples/cucubmer7/cucumber7-gradle-testng/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     testImplementation("io.cucumber:cucumber-core:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-java:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-testng:$cucumberVersion")
-    testImplementation("io.qase:qase-cucumber-v7-reporter:4.1.26")
+    testImplementation("io.qase:qase-cucumber-v7-reporter:4.1.27")
 }
 
 test {

--- a/examples/cucubmer7/cucumber7-gradlekts-junit5/build.gradle.kts
+++ b/examples/cucubmer7/cucumber7-gradlekts-junit5/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
     testImplementation("io.cucumber:cucumber-core:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-java:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-junit-platform-engine:$cucumberVersion")
-    testImplementation("io.qase:qase-cucumber-v7-reporter:4.1.26")
+    testImplementation("io.qase:qase-cucumber-v7-reporter:4.1.27")
 }
 
 tasks.test {

--- a/examples/cucubmer7/cucumber7-maven-junit4/pom.xml
+++ b/examples/cucubmer7/cucumber7-maven-junit4/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aspectj.version>1.9.22</aspectj.version>
-        <qase.version>4.1.26</qase.version>
+        <qase.version>4.1.27</qase.version>
         <cucumber.version>7.14.0</cucumber.version>
     </properties>
 

--- a/examples/cucubmer7/cucumber7-maven-junit5/pom.xml
+++ b/examples/cucubmer7/cucumber7-maven-junit5/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aspectj.version>1.9.22</aspectj.version>
-        <qase.version>4.1.26</qase.version>
+        <qase.version>4.1.27</qase.version>
         <cucumber.version>7.14.0</cucumber.version>
     </properties>
 

--- a/examples/cucubmer7/cucumber7-maven-testng/pom.xml
+++ b/examples/cucubmer7/cucumber7-maven-testng/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aspectj.version>1.9.22</aspectj.version>
-        <qase.version>4.1.26</qase.version>
+        <qase.version>4.1.27</qase.version>
         <cucumber.version>7.14.0</cucumber.version>
     </properties>
 

--- a/examples/junit4/junit4-gradle/build.gradle
+++ b/examples/junit4/junit4-gradle/build.gradle
@@ -17,7 +17,7 @@ repositories {
 dependencies {
     testImplementation 'junit:junit:4.13.1'
     testImplementation "org.junit.platform:junit-platform-runner:1.6.3"
-    testImplementation("io.qase:qase-junit4-reporter:4.1.26")
+    testImplementation("io.qase:qase-junit4-reporter:4.1.27")
     aspectConfig "org.aspectj:aspectjweaver:1.9.22"
 }
 

--- a/examples/junit4/junit4-maven/pom.xml
+++ b/examples/junit4/junit4-maven/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aspectj.version>1.9.22</aspectj.version>
-        <qase.version>4.1.26</qase.version>
+        <qase.version>4.1.27</qase.version>
     </properties>
 
     <dependencies>

--- a/examples/junit5/junit5-bazel/WORKSPACE
+++ b/examples/junit5/junit5-bazel/WORKSPACE
@@ -19,7 +19,7 @@ maven_install(
         "org.junit.jupiter:junit-jupiter-params:5.11.2",
         "org.junit.jupiter:junit-jupiter-engine:5.11.2",
         "org.junit.platform:junit-platform-console-standalone:1.11.4",
-        "io.qase:qase-junit5-reporter:4.1.26",
+        "io.qase:qase-junit5-reporter:4.1.27",
         "org.aspectj:aspectjweaver:1.9.22",
         "org.aspectj:aspectjrt:1.9.22",
         "org.slf4j:slf4j-api:1.7.32"

--- a/examples/junit5/junit5-gradle/build.gradle
+++ b/examples/junit5/junit5-gradle/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-params'
     testImplementation 'org.junit.jupiter:junit-jupiter-engine'
     testImplementation 'org.junit.platform:junit-platform-launcher'
-    testImplementation('io.qase:qase-junit5-reporter:4.1.26')
+    testImplementation('io.qase:qase-junit5-reporter:4.1.27')
     aspectConfig "org.aspectj:aspectjweaver:1.9.22"
 }
 

--- a/examples/junit5/junit5-maven/pom.xml
+++ b/examples/junit5/junit5-maven/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aspectj.version>1.9.22</aspectj.version>
-        <qase.version>4.1.26</qase.version>
+        <qase.version>4.1.27</qase.version>
     </properties>
 
     <dependencies>

--- a/examples/kotlin/junit4/build.gradle.kts
+++ b/examples/kotlin/junit4/build.gradle.kts
@@ -22,7 +22,7 @@ tasks.withType<JavaCompile>().configureEach {
 dependencies {
     testImplementation(kotlin("test"))
     testImplementation("junit:junit:4.13.1")
-    testImplementation("io.qase:qase-junit4-reporter:4.1.26")
+    testImplementation("io.qase:qase-junit4-reporter:4.1.27")
     "aspectConfig"("org.aspectj:aspectjweaver:1.9.22")
 }
 

--- a/examples/kotlin/junit5/build.gradle.kts
+++ b/examples/kotlin/junit5/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.0")
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.10.0")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.10.0")
-    testImplementation("io.qase:qase-junit5-reporter:4.1.26")
+    testImplementation("io.qase:qase-junit5-reporter:4.1.27")
     "aspectConfig"("org.aspectj:aspectjweaver:1.9.22")
 }
 

--- a/examples/kotlin/testng/build.gradle.kts
+++ b/examples/kotlin/testng/build.gradle.kts
@@ -22,7 +22,7 @@ tasks.withType<JavaCompile>().configureEach {
 dependencies {
     testImplementation(kotlin("test"))
     testImplementation("org.testng:testng:7.5")
-    testImplementation("io.qase:qase-testng-reporter:4.1.26")
+    testImplementation("io.qase:qase-testng-reporter:4.1.27")
     "aspectConfig"("org.aspectj:aspectjweaver:1.9.22")
 }
 

--- a/examples/testng/testng-gradle/build.gradle
+++ b/examples/testng/testng-gradle/build.gradle
@@ -24,7 +24,7 @@ repositories {
 dependencies {
     testImplementation "org.aspectj:aspectjrt:1.9.22"
     testImplementation "org.testng:testng:7.5"
-    testImplementation 'io.qase:qase-testng-reporter:4.1.26'
+    testImplementation 'io.qase:qase-testng-reporter:4.1.27'
     aspectConfig "org.aspectj:aspectjweaver:1.9.22"
 }
 

--- a/examples/testng/testng-maven/pom.xml
+++ b/examples/testng/testng-maven/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aspectj.version>1.9.22</aspectj.version>
-        <qase.version>4.1.26</qase.version>
+        <qase.version>4.1.27</qase.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.qase</groupId>
     <artifactId>qase-java</artifactId>
     <packaging>pom</packaging>
-    <version>4.1.26</version>
+    <version>4.1.27</version>
     <modules>
         <module>qase-java-commons</module>
         <module>qase-api-client</module>

--- a/qase-api-client/pom.xml
+++ b/qase-api-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.26</version>
+        <version>4.1.27</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-api-v2-client/pom.xml
+++ b/qase-api-v2-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.qase</groupId>
         <artifactId>qase-java</artifactId>
-        <version>4.1.26</version>
+        <version>4.1.27</version>
     </parent>
 
     <artifactId>qase-api-v2-client</artifactId>

--- a/qase-cucumber-v3-reporter/pom.xml
+++ b/qase-cucumber-v3-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.26</version>
+        <version>4.1.27</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v4-reporter/pom.xml
+++ b/qase-cucumber-v4-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.26</version>
+        <version>4.1.27</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v5-reporter/pom.xml
+++ b/qase-cucumber-v5-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.26</version>
+        <version>4.1.27</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v6-reporter/pom.xml
+++ b/qase-cucumber-v6-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.26</version>
+        <version>4.1.27</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v7-reporter/pom.xml
+++ b/qase-cucumber-v7-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.26</version>
+        <version>4.1.27</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-java-commons/pom.xml
+++ b/qase-java-commons/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.qase</groupId>
         <artifactId>qase-java</artifactId>
-        <version>4.1.26</version>
+        <version>4.1.27</version>
     </parent>
 
     <artifactId>qase-java-commons</artifactId>

--- a/qase-java-commons/src/main/java/io/qase/commons/utils/ClientHeadersBuilder.java
+++ b/qase-java-commons/src/main/java/io/qase/commons/utils/ClientHeadersBuilder.java
@@ -54,7 +54,7 @@ public class ClientHeadersBuilder {
             parts.add("reporter=" + reporterName);
         }
         if (reporterVersion != null && !reporterVersion.isEmpty()) {
-            parts.add("reporter_version=v" + ensureNoVPrefix(reporterVersion));
+            parts.add("reporter_version=" + ensureNoVPrefix(reporterVersion));
         }
         
         // Add framework info
@@ -67,15 +67,15 @@ public class ClientHeadersBuilder {
         
         // Add client versions
         if (apiClientV1Version != null && !apiClientV1Version.isEmpty()) {
-            parts.add("client_version_v1=v" + ensureNoVPrefix(apiClientV1Version));
+            parts.add("client_version_v1=" + ensureNoVPrefix(apiClientV1Version));
         }
         if (apiClientV2Version != null && !apiClientV2Version.isEmpty()) {
-            parts.add("client_version_v2=v" + ensureNoVPrefix(apiClientV2Version));
+            parts.add("client_version_v2=" + ensureNoVPrefix(apiClientV2Version));
         }
         
         // Add core version
         if (commonsVersion != null && !commonsVersion.isEmpty()) {
-            parts.add("core_version=v" + ensureNoVPrefix(commonsVersion));
+            parts.add("core_version=" + ensureNoVPrefix(commonsVersion));
         }
         
         return String.join(";", parts);

--- a/qase-junit4-reporter/pom.xml
+++ b/qase-junit4-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.26</version>
+        <version>4.1.27</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-junit5-reporter/pom.xml
+++ b/qase-junit5-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.26</version>
+        <version>4.1.27</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-testng-reporter/pom.xml
+++ b/qase-testng-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.26</version>
+        <version>4.1.27</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
- Updated version number to 4.1.27 in all relevant pom.xml and build.gradle files.
- Adjusted reporter versioning format in ClientHeadersBuilder for consistency.
- Updated changelog to reflect the new version and changes made.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps all modules/examples to 4.1.27 and updates ClientHeadersBuilder to emit header version fields without a leading "v".
> 
> - **Versions**:
>   - Bump to `4.1.27` in root `pom.xml`, all module POMs, and example builds (`Gradle`/`Maven`/`Bazel`) for JUnit/TestNG/Cucumber reporters.
> - **Headers**:
>   - In `qase-java-commons` `ClientHeadersBuilder`, remove leading `v` from version fields in `X-Client` (`reporter_version`, `client_version_v1`, `client_version_v2`, `core_version`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d0733efb034f6318ef5c6afd71a9b2dc5997c4c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->