### PR TITLE
chore: update version to 4.1.28 and fix root suite issue in reporters

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+# qase-java 4.1.28
+
+## What's new
+
+- Fixed issue with root suite in reporters.
+
 # qase-java 4.1.25
 
 ## What's new

--- a/examples/cucubmer3/cucubmer3-gradle/build.gradle
+++ b/examples/cucubmer3/cucubmer3-gradle/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     testImplementation("io.cucumber:cucumber-core:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-java:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-testng:$cucumberVersion")
-    testImplementation("io.qase:qase-cucumber-v3-reporter:4.1.27")
+    testImplementation("io.qase:qase-cucumber-v3-reporter:4.1.28")
 }
 
 test {

--- a/examples/cucubmer3/cucumber3-maven/pom.xml
+++ b/examples/cucubmer3/cucumber3-maven/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aspectj.version>1.9.22</aspectj.version>
-        <qase.version>4.1.27</qase.version>
+        <qase.version>4.1.28</qase.version>
     </properties>
 
     <dependencies>

--- a/examples/cucubmer4/cucubmer4-gradle/build.gradle
+++ b/examples/cucubmer4/cucubmer4-gradle/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     testImplementation("io.cucumber:cucumber-core:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-java:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-testng:$cucumberVersion")
-    testImplementation("io.qase:qase-cucumber-v4-reporter:4.1.27")
+    testImplementation("io.qase:qase-cucumber-v4-reporter:4.1.28")
 }
 
 test {

--- a/examples/cucubmer4/cucumber4-maven/pom.xml
+++ b/examples/cucubmer4/cucumber4-maven/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aspectj.version>1.9.22</aspectj.version>
-        <qase.version>4.1.27</qase.version>
+        <qase.version>4.1.28</qase.version>
     </properties>
 
     <dependencies>

--- a/examples/cucubmer5/cucubmer5-gradle/build.gradle
+++ b/examples/cucubmer5/cucubmer5-gradle/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     testImplementation("io.cucumber:cucumber-core:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-java:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-testng:$cucumberVersion")
-    testImplementation("io.qase:qase-cucumber-v5-reporter:4.1.27")
+    testImplementation("io.qase:qase-cucumber-v5-reporter:4.1.28")
 }
 
 test {

--- a/examples/cucubmer5/cucumber5-maven/pom.xml
+++ b/examples/cucubmer5/cucumber5-maven/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aspectj.version>1.9.22</aspectj.version>
-        <qase.version>4.1.27</qase.version>
+        <qase.version>4.1.28</qase.version>
     </properties>
 
     <dependencies>

--- a/examples/cucubmer6/cucubmer6-gradle/build.gradle
+++ b/examples/cucubmer6/cucubmer6-gradle/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     testImplementation("io.cucumber:cucumber-core:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-java:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-testng:$cucumberVersion")
-    testImplementation("io.qase:qase-cucumber-v6-reporter:4.1.27")
+    testImplementation("io.qase:qase-cucumber-v6-reporter:4.1.28")
 }
 
 test {

--- a/examples/cucubmer6/cucumber6-maven/pom.xml
+++ b/examples/cucubmer6/cucumber6-maven/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aspectj.version>1.9.22</aspectj.version>
-        <qase.version>4.1.27</qase.version>
+        <qase.version>4.1.28</qase.version>
         <cucumber.version>6.11.0</cucumber.version>
     </properties>
 

--- a/examples/cucubmer7/cucumber7-gradle-junit4/build.gradle
+++ b/examples/cucubmer7/cucumber7-gradle-junit4/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     testImplementation("io.cucumber:cucumber-core:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-java:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-junit:$cucumberVersion")
-    testImplementation("io.qase:qase-cucumber-v7-reporter:4.1.27")
+    testImplementation("io.qase:qase-cucumber-v7-reporter:4.1.28")
 }
 
 test {

--- a/examples/cucubmer7/cucumber7-gradle-junit5/build.gradle
+++ b/examples/cucubmer7/cucumber7-gradle-junit5/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     testImplementation("io.cucumber:cucumber-core:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-java:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-junit-platform-engine:$cucumberVersion")
-    testImplementation("io.qase:qase-cucumber-v7-reporter:4.1.27")
+    testImplementation("io.qase:qase-cucumber-v7-reporter:4.1.28")
 }
 
 test {

--- a/examples/cucubmer7/cucumber7-gradle-testng/build.gradle
+++ b/examples/cucubmer7/cucumber7-gradle-testng/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     testImplementation("io.cucumber:cucumber-core:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-java:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-testng:$cucumberVersion")
-    testImplementation("io.qase:qase-cucumber-v7-reporter:4.1.27")
+    testImplementation("io.qase:qase-cucumber-v7-reporter:4.1.28")
 }
 
 test {

--- a/examples/cucubmer7/cucumber7-gradlekts-junit5/build.gradle.kts
+++ b/examples/cucubmer7/cucumber7-gradlekts-junit5/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
     testImplementation("io.cucumber:cucumber-core:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-java:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-junit-platform-engine:$cucumberVersion")
-    testImplementation("io.qase:qase-cucumber-v7-reporter:4.1.27")
+    testImplementation("io.qase:qase-cucumber-v7-reporter:4.1.28")
 }
 
 tasks.test {

--- a/examples/cucubmer7/cucumber7-maven-junit4/pom.xml
+++ b/examples/cucubmer7/cucumber7-maven-junit4/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aspectj.version>1.9.22</aspectj.version>
-        <qase.version>4.1.27</qase.version>
+        <qase.version>4.1.28</qase.version>
         <cucumber.version>7.14.0</cucumber.version>
     </properties>
 

--- a/examples/cucubmer7/cucumber7-maven-junit5/pom.xml
+++ b/examples/cucubmer7/cucumber7-maven-junit5/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aspectj.version>1.9.22</aspectj.version>
-        <qase.version>4.1.27</qase.version>
+        <qase.version>4.1.28</qase.version>
         <cucumber.version>7.14.0</cucumber.version>
     </properties>
 

--- a/examples/cucubmer7/cucumber7-maven-testng/pom.xml
+++ b/examples/cucubmer7/cucumber7-maven-testng/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aspectj.version>1.9.22</aspectj.version>
-        <qase.version>4.1.27</qase.version>
+        <qase.version>4.1.28</qase.version>
         <cucumber.version>7.14.0</cucumber.version>
     </properties>
 

--- a/examples/junit4/junit4-gradle/build.gradle
+++ b/examples/junit4/junit4-gradle/build.gradle
@@ -17,7 +17,7 @@ repositories {
 dependencies {
     testImplementation 'junit:junit:4.13.1'
     testImplementation "org.junit.platform:junit-platform-runner:1.6.3"
-    testImplementation("io.qase:qase-junit4-reporter:4.1.27")
+    testImplementation("io.qase:qase-junit4-reporter:4.1.28")
     aspectConfig "org.aspectj:aspectjweaver:1.9.22"
 }
 

--- a/examples/junit4/junit4-maven/pom.xml
+++ b/examples/junit4/junit4-maven/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aspectj.version>1.9.22</aspectj.version>
-        <qase.version>4.1.27</qase.version>
+        <qase.version>4.1.28</qase.version>
     </properties>
 
     <dependencies>

--- a/examples/junit5/junit5-bazel/WORKSPACE
+++ b/examples/junit5/junit5-bazel/WORKSPACE
@@ -19,7 +19,7 @@ maven_install(
         "org.junit.jupiter:junit-jupiter-params:5.11.2",
         "org.junit.jupiter:junit-jupiter-engine:5.11.2",
         "org.junit.platform:junit-platform-console-standalone:1.11.4",
-        "io.qase:qase-junit5-reporter:4.1.27",
+        "io.qase:qase-junit5-reporter:4.1.28",
         "org.aspectj:aspectjweaver:1.9.22",
         "org.aspectj:aspectjrt:1.9.22",
         "org.slf4j:slf4j-api:1.7.32"

--- a/examples/junit5/junit5-gradle/build.gradle
+++ b/examples/junit5/junit5-gradle/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-params'
     testImplementation 'org.junit.jupiter:junit-jupiter-engine'
     testImplementation 'org.junit.platform:junit-platform-launcher'
-    testImplementation('io.qase:qase-junit5-reporter:4.1.27')
+    testImplementation('io.qase:qase-junit5-reporter:4.1.28')
     aspectConfig "org.aspectj:aspectjweaver:1.9.22"
 }
 

--- a/examples/junit5/junit5-maven/pom.xml
+++ b/examples/junit5/junit5-maven/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aspectj.version>1.9.22</aspectj.version>
-        <qase.version>4.1.27</qase.version>
+        <qase.version>4.1.28</qase.version>
     </properties>
 
     <dependencies>

--- a/examples/kotlin/junit4/build.gradle.kts
+++ b/examples/kotlin/junit4/build.gradle.kts
@@ -22,7 +22,7 @@ tasks.withType<JavaCompile>().configureEach {
 dependencies {
     testImplementation(kotlin("test"))
     testImplementation("junit:junit:4.13.1")
-    testImplementation("io.qase:qase-junit4-reporter:4.1.27")
+    testImplementation("io.qase:qase-junit4-reporter:4.1.28")
     "aspectConfig"("org.aspectj:aspectjweaver:1.9.22")
 }
 

--- a/examples/kotlin/junit5/build.gradle.kts
+++ b/examples/kotlin/junit5/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.0")
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.10.0")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.10.0")
-    testImplementation("io.qase:qase-junit5-reporter:4.1.27")
+    testImplementation("io.qase:qase-junit5-reporter:4.1.28")
     "aspectConfig"("org.aspectj:aspectjweaver:1.9.22")
 }
 

--- a/examples/kotlin/testng/build.gradle.kts
+++ b/examples/kotlin/testng/build.gradle.kts
@@ -22,7 +22,7 @@ tasks.withType<JavaCompile>().configureEach {
 dependencies {
     testImplementation(kotlin("test"))
     testImplementation("org.testng:testng:7.5")
-    testImplementation("io.qase:qase-testng-reporter:4.1.27")
+    testImplementation("io.qase:qase-testng-reporter:4.1.28")
     "aspectConfig"("org.aspectj:aspectjweaver:1.9.22")
 }
 

--- a/examples/testng/testng-gradle/build.gradle
+++ b/examples/testng/testng-gradle/build.gradle
@@ -24,7 +24,7 @@ repositories {
 dependencies {
     testImplementation "org.aspectj:aspectjrt:1.9.22"
     testImplementation "org.testng:testng:7.5"
-    testImplementation 'io.qase:qase-testng-reporter:4.1.27'
+    testImplementation 'io.qase:qase-testng-reporter:4.1.28'
     aspectConfig "org.aspectj:aspectjweaver:1.9.22"
 }
 

--- a/examples/testng/testng-maven/pom.xml
+++ b/examples/testng/testng-maven/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aspectj.version>1.9.22</aspectj.version>
-        <qase.version>4.1.27</qase.version>
+        <qase.version>4.1.28</qase.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.qase</groupId>
     <artifactId>qase-java</artifactId>
     <packaging>pom</packaging>
-    <version>4.1.27</version>
+    <version>4.1.28</version>
     <modules>
         <module>qase-java-commons</module>
         <module>qase-api-client</module>

--- a/qase-api-client/pom.xml
+++ b/qase-api-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.27</version>
+        <version>4.1.28</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-api-v2-client/pom.xml
+++ b/qase-api-v2-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.qase</groupId>
         <artifactId>qase-java</artifactId>
-        <version>4.1.27</version>
+        <version>4.1.28</version>
     </parent>
 
     <artifactId>qase-api-v2-client</artifactId>

--- a/qase-cucumber-v3-reporter/pom.xml
+++ b/qase-cucumber-v3-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.27</version>
+        <version>4.1.28</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v4-reporter/pom.xml
+++ b/qase-cucumber-v4-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.27</version>
+        <version>4.1.28</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v5-reporter/pom.xml
+++ b/qase-cucumber-v5-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.27</version>
+        <version>4.1.28</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v6-reporter/pom.xml
+++ b/qase-cucumber-v6-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.27</version>
+        <version>4.1.28</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v7-reporter/pom.xml
+++ b/qase-cucumber-v7-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.27</version>
+        <version>4.1.28</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-java-commons/pom.xml
+++ b/qase-java-commons/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.qase</groupId>
         <artifactId>qase-java</artifactId>
-        <version>4.1.27</version>
+        <version>4.1.28</version>
     </parent>
 
     <artifactId>qase-java-commons</artifactId>

--- a/qase-junit4-reporter/pom.xml
+++ b/qase-junit4-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.27</version>
+        <version>4.1.28</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-junit5-reporter/pom.xml
+++ b/qase-junit5-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.27</version>
+        <version>4.1.28</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-testng-reporter/pom.xml
+++ b/qase-testng-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.27</version>
+        <version>4.1.28</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
- Updated version number to 4.1.28 in all relevant pom.xml and build.gradle files.
- Fixed issue with root suite handling in reporters to ensure proper suite hierarchy.
- Updated changelog to reflect the new version and changes made.

#209 