### PR TITLE
fix: filter empty suite titles from Cucumber URI path parts

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+# qase-java 4.1.51
+
+## Bug fixes
+
+- Fixed Cucumber reporters failing to upload results with HTTP 422 error when feature files are resolved via `file:///` URI (common with Gradle). Splitting the URI on `/` produced empty path segments that were sent as suite entries with blank titles, which the API rejected. Empty and blank segments are now filtered out before building suite relations. Affects all Cucumber reporter versions (v3–v7).
+
 # qase-java 4.1.50
 
 ## What's new

--- a/examples/cucumber3/cucumber3-gradle/build.gradle
+++ b/examples/cucumber3/cucumber3-gradle/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     testImplementation("io.cucumber:cucumber-core:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-java:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-testng:$cucumberVersion")
-    testImplementation("io.qase:qase-cucumber-v3-reporter:4.1.41")
+    testImplementation("io.qase:qase-cucumber-v3-reporter:4.1.51")
 }
 
 test {

--- a/examples/cucumber3/cucumber3-maven/pom.xml
+++ b/examples/cucumber3/cucumber3-maven/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aspectj.version>1.9.22</aspectj.version>
-        <qase.version>4.1.42</qase.version>
+        <qase.version>4.1.51</qase.version>
     </properties>
 
     <dependencies>

--- a/examples/cucumber4/cucumber4-gradle/build.gradle
+++ b/examples/cucumber4/cucumber4-gradle/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     testImplementation("io.cucumber:cucumber-core:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-java:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-testng:$cucumberVersion")
-    testImplementation("io.qase:qase-cucumber-v4-reporter:4.1.41")
+    testImplementation("io.qase:qase-cucumber-v4-reporter:4.1.51")
 }
 
 test {

--- a/examples/cucumber4/cucumber4-maven/pom.xml
+++ b/examples/cucumber4/cucumber4-maven/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aspectj.version>1.9.22</aspectj.version>
-        <qase.version>4.1.42</qase.version>
+        <qase.version>4.1.51</qase.version>
     </properties>
 
     <dependencies>

--- a/examples/cucumber5/cucumber5-gradle/build.gradle
+++ b/examples/cucumber5/cucumber5-gradle/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     testImplementation("io.cucumber:cucumber-core:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-java:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-testng:$cucumberVersion")
-    testImplementation("io.qase:qase-cucumber-v5-reporter:4.1.41")
+    testImplementation("io.qase:qase-cucumber-v5-reporter:4.1.51")
 }
 
 test {

--- a/examples/cucumber5/cucumber5-maven/pom.xml
+++ b/examples/cucumber5/cucumber5-maven/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aspectj.version>1.9.22</aspectj.version>
-        <qase.version>4.1.50</qase.version>
+        <qase.version>4.1.51</qase.version>
     </properties>
 
     <dependencies>

--- a/examples/cucumber6/cucumber6-gradle/build.gradle
+++ b/examples/cucumber6/cucumber6-gradle/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     testImplementation("io.cucumber:cucumber-core:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-java:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-testng:$cucumberVersion")
-    testImplementation("io.qase:qase-cucumber-v6-reporter:4.1.41")
+    testImplementation("io.qase:qase-cucumber-v6-reporter:4.1.51")
 }
 
 test {

--- a/examples/cucumber6/cucumber6-maven/pom.xml
+++ b/examples/cucumber6/cucumber6-maven/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aspectj.version>1.9.22</aspectj.version>
-        <qase.version>4.1.42</qase.version>
+        <qase.version>4.1.51</qase.version>
         <cucumber.version>6.11.0</cucumber.version>
     </properties>
 

--- a/examples/cucumber7/cucumber7-gradle-junit4/build.gradle
+++ b/examples/cucumber7/cucumber7-gradle-junit4/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     testImplementation("io.cucumber:cucumber-core:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-java:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-junit:$cucumberVersion")
-    testImplementation("io.qase:qase-cucumber-v7-reporter:4.1.41")
+    testImplementation("io.qase:qase-cucumber-v7-reporter:4.1.51")
 }
 
 test {

--- a/examples/cucumber7/cucumber7-gradle-junit5/build.gradle
+++ b/examples/cucumber7/cucumber7-gradle-junit5/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     testImplementation("io.cucumber:cucumber-core:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-java:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-junit-platform-engine:$cucumberVersion")
-    testImplementation("io.qase:qase-cucumber-v7-reporter:4.1.41")
+    testImplementation("io.qase:qase-cucumber-v7-reporter:4.1.51")
 }
 
 test {

--- a/examples/cucumber7/cucumber7-gradle-testng/build.gradle
+++ b/examples/cucumber7/cucumber7-gradle-testng/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     testImplementation("io.cucumber:cucumber-core:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-java:$cucumberVersion")
     testImplementation("io.cucumber:cucumber-testng:$cucumberVersion")
-    testImplementation("io.qase:qase-cucumber-v7-reporter:4.1.41")
+    testImplementation("io.qase:qase-cucumber-v7-reporter:4.1.51")
 }
 
 test {

--- a/examples/cucumber7/cucumber7-maven-junit4/pom.xml
+++ b/examples/cucumber7/cucumber7-maven-junit4/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aspectj.version>1.9.22</aspectj.version>
-        <qase.version>4.1.42</qase.version>
+        <qase.version>4.1.51</qase.version>
         <cucumber.version>7.14.0</cucumber.version>
     </properties>
 

--- a/examples/cucumber7/cucumber7-maven-junit5/pom.xml
+++ b/examples/cucumber7/cucumber7-maven-junit5/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aspectj.version>1.9.22</aspectj.version>
-        <qase.version>4.1.50</qase.version>
+        <qase.version>4.1.51</qase.version>
         <cucumber.version>7.14.0</cucumber.version>
     </properties>
 

--- a/examples/cucumber7/cucumber7-maven-testng/pom.xml
+++ b/examples/cucumber7/cucumber7-maven-testng/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aspectj.version>1.9.22</aspectj.version>
-        <qase.version>4.1.42</qase.version>
+        <qase.version>4.1.51</qase.version>
         <cucumber.version>7.14.0</cucumber.version>
     </properties>
 

--- a/examples/junit4/junit4-gradle/build.gradle
+++ b/examples/junit4/junit4-gradle/build.gradle
@@ -17,7 +17,7 @@ repositories {
 dependencies {
     testImplementation 'junit:junit:4.13.1'
     testImplementation "org.junit.platform:junit-platform-runner:1.6.3"
-    testImplementation("io.qase:qase-junit4-reporter:4.1.41")
+    testImplementation("io.qase:qase-junit4-reporter:4.1.51")
     aspectConfig "org.aspectj:aspectjweaver:1.9.22"
 }
 

--- a/examples/junit4/junit4-maven/pom.xml
+++ b/examples/junit4/junit4-maven/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aspectj.version>1.9.22</aspectj.version>
-        <qase.version>4.1.50</qase.version>
+        <qase.version>4.1.51</qase.version>
     </properties>
 
     <dependencies>

--- a/examples/junit5/junit5-gradle/build.gradle
+++ b/examples/junit5/junit5-gradle/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-params'
     testImplementation 'org.junit.jupiter:junit-jupiter-engine'
     testImplementation 'org.junit.platform:junit-platform-launcher'
-    testImplementation('io.qase:qase-junit5-reporter:4.1.41')
+    testImplementation('io.qase:qase-junit5-reporter:4.1.51')
     aspectConfig "org.aspectj:aspectjweaver:1.9.22"
 }
 

--- a/examples/junit5/junit5-maven/pom.xml
+++ b/examples/junit5/junit5-maven/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aspectj.version>1.9.25.1</aspectj.version>
-        <qase.version>4.1.50</qase.version>
+        <qase.version>4.1.51</qase.version>
     </properties>
 
     <dependencyManagement>

--- a/examples/testng/testng-gradle/build.gradle
+++ b/examples/testng/testng-gradle/build.gradle
@@ -24,7 +24,7 @@ repositories {
 dependencies {
     testImplementation "org.aspectj:aspectjrt:1.9.22"
     testImplementation "org.testng:testng:7.5.1"
-    testImplementation 'io.qase:qase-testng-reporter:4.1.41'
+    testImplementation 'io.qase:qase-testng-reporter:4.1.51'
     aspectConfig "org.aspectj:aspectjweaver:1.9.22"
 }
 

--- a/examples/testng/testng-maven/pom.xml
+++ b/examples/testng/testng-maven/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aspectj.version>1.9.22</aspectj.version>
-        <qase.version>4.1.50</qase.version>
+        <qase.version>4.1.51</qase.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.qase</groupId>
     <artifactId>qase-java</artifactId>
     <packaging>pom</packaging>
-    <version>4.1.50</version>
+    <version>4.1.51</version>
     <modules>
         <module>qase-java-commons</module>
         <module>qase-api-client</module>

--- a/qase-api-client/pom.xml
+++ b/qase-api-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.50</version>
+        <version>4.1.51</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-api-v2-client/pom.xml
+++ b/qase-api-v2-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.qase</groupId>
         <artifactId>qase-java</artifactId>
-        <version>4.1.50</version>
+        <version>4.1.51</version>
     </parent>
 
     <artifactId>qase-api-v2-client</artifactId>

--- a/qase-cucumber-v3-reporter/pom.xml
+++ b/qase-cucumber-v3-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.50</version>
+        <version>4.1.51</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v4-reporter/pom.xml
+++ b/qase-cucumber-v4-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.50</version>
+        <version>4.1.51</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v5-reporter/pom.xml
+++ b/qase-cucumber-v5-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.50</version>
+        <version>4.1.51</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v6-reporter/pom.xml
+++ b/qase-cucumber-v6-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.50</version>
+        <version>4.1.51</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v7-reporter/pom.xml
+++ b/qase-cucumber-v7-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.50</version>
+        <version>4.1.51</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-java-commons/pom.xml
+++ b/qase-java-commons/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.qase</groupId>
         <artifactId>qase-java</artifactId>
-        <version>4.1.50</version>
+        <version>4.1.51</version>
     </parent>
 
     <artifactId>qase-java-commons</artifactId>

--- a/qase-java-commons/src/main/java/io/qase/commons/utils/TestResultBuilder.java
+++ b/qase-java-commons/src/main/java/io/qase/commons/utils/TestResultBuilder.java
@@ -278,12 +278,18 @@ public final class TestResultBuilder {
             // Cucumber uses literal "\\t" (two chars) not tab
             String[] parts = suite.split("\\\\t");
             for (String part : parts) {
+                if (part == null || part.trim().isEmpty()) {
+                    continue;
+                }
                 SuiteData data = new SuiteData();
                 data.title = part;
                 relations.suite.data.add(data);
             }
         } else {
             for (String part : uriPathParts) {
+                if (part == null || part.trim().isEmpty()) {
+                    continue;
+                }
                 SuiteData data = new SuiteData();
                 data.title = part;
                 relations.suite.data.add(data);

--- a/qase-java-commons/src/test/java/io/qase/commons/utils/TestResultBuilderTest.java
+++ b/qase-java-commons/src/test/java/io/qase/commons/utils/TestResultBuilderTest.java
@@ -492,6 +492,33 @@ class TestResultBuilderTest {
     }
 
     @Test
+    void fromCucumber_fileUriPathPartsWithEmptySegments_filtersOutBlanks() {
+        // Simulates file:///absolute/path/features/file.feature split on "/"
+        // which produces ["file:", "", "", "absolute", "path", "features", "file.feature"]
+        StubAdapter adapter = new StubAdapter(
+                Collections.<String>emptyList(),
+                "My Scenario",
+                Arrays.asList("file:", "", "", "absolute", "path", "features", "file.feature")
+        );
+
+        TestResult result = TestResultBuilder.fromCucumber(adapter, Collections.<String, String>emptyMap(), 0L);
+
+        assertNotNull(result.relations);
+        assertNotNull(result.relations.suite);
+        // Empty segments must be filtered out
+        for (SuiteData sd : result.relations.suite.data) {
+            assertNotNull(sd.title);
+            assertFalse(sd.title.trim().isEmpty(), "Suite title must not be blank");
+        }
+        assertEquals(5, result.relations.suite.data.size());
+        assertEquals("file:", result.relations.suite.data.get(0).title);
+        assertEquals("absolute", result.relations.suite.data.get(1).title);
+        assertEquals("path", result.relations.suite.data.get(2).title);
+        assertEquals("features", result.relations.suite.data.get(3).title);
+        assertEquals("file.feature", result.relations.suite.data.get(4).title);
+    }
+
+    @Test
     void fromCucumber_withQaseTagsTag_setsTagsList() {
         StubAdapter adapter = new StubAdapter(
                 Arrays.asList("@QaseId=42", "@QaseTags=smoke,regression"),

--- a/qase-junit4-reporter/pom.xml
+++ b/qase-junit4-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.50</version>
+        <version>4.1.51</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-junit5-reporter/pom.xml
+++ b/qase-junit5-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.50</version>
+        <version>4.1.51</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-testng-reporter/pom.xml
+++ b/qase-testng-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.50</version>
+        <version>4.1.51</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
## Summary

- Fixed Cucumber reporters failing to upload results with HTTP 422 when feature files are resolved via `file:///` URI (common with Gradle)
- Splitting the URI on `/` produced empty path segments sent as suite entries with blank titles — the API rejected them with `"relations.suite.data.1.title field is required"`
- Empty/blank segments are now filtered out in `buildCucumberRelations()` before building suite relations
- Affects all Cucumber reporter versions (v3–v7)
- Bumped version to 4.1.51 and updated all example projects

## Root Cause

`V7TestCaseAdapter.getUriPathParts()` calls `testCase.getUri().toString().split("/")`. For a `file:///path/to/features/file.feature` URI, `split("/")` produces `["file:", "", "", "path", ...]` — empty strings at indices 1 and 2 from the triple slash. These become `SuiteData` objects with empty `title`, which the Qase API rejects (422).

## Test plan

- [x] Added unit test `fromCucumber_fileUriPathPartsWithEmptySegments_filtersOutBlanks` that reproduces the exact scenario
- [x] All 26 existing `TestResultBuilderTest` tests pass
- [ ] Manual verification with Cucumber v7 + Gradle + TestNG example project