### PR TITLE
fix: drop non-positive Qase case ids before batch upload

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+# qase-java 4.1.53
+
+## Bug fixes
+
+- Fixed a single `@QaseId(0)` (or any non-positive id) wiping every result in a bulk upload. Qase TestOps rejected the whole batch with HTTP 422 (`testops_ids must be a positive integer`), and because uploads are all-or-nothing, the run was created but ended up empty. Non-positive ids from `@QaseId`, `@QaseIds`, legacy `@CaseId` and Cucumber `@QaseId=...` / `@QaseIds=...` tags are now dropped before the signature is built and before the batch is sent; the result is uploaded as untagged when no valid id remains. A `WARN` log makes the dropped placeholder visible without `QASE_DEBUG=true`.
+
 # qase-java 4.1.52
 
 - Updated API clients to the latest specification

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.qase</groupId>
     <artifactId>qase-java</artifactId>
     <packaging>pom</packaging>
-    <version>4.1.52</version>
+    <version>4.1.53</version>
     <modules>
         <module>qase-java-commons</module>
         <module>qase-api-client</module>

--- a/qase-api-client/pom.xml
+++ b/qase-api-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.52</version>
+        <version>4.1.53</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-api-v2-client/pom.xml
+++ b/qase-api-v2-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.qase</groupId>
         <artifactId>qase-java</artifactId>
-        <version>4.1.52</version>
+        <version>4.1.53</version>
     </parent>
 
     <artifactId>qase-api-v2-client</artifactId>

--- a/qase-cucumber-v3-reporter/pom.xml
+++ b/qase-cucumber-v3-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.52</version>
+        <version>4.1.53</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v4-reporter/pom.xml
+++ b/qase-cucumber-v4-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.52</version>
+        <version>4.1.53</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v5-reporter/pom.xml
+++ b/qase-cucumber-v5-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.52</version>
+        <version>4.1.53</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v6-reporter/pom.xml
+++ b/qase-cucumber-v6-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.52</version>
+        <version>4.1.53</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v7-reporter/pom.xml
+++ b/qase-cucumber-v7-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.52</version>
+        <version>4.1.53</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-java-commons/pom.xml
+++ b/qase-java-commons/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.qase</groupId>
         <artifactId>qase-java</artifactId>
-        <version>4.1.52</version>
+        <version>4.1.53</version>
     </parent>
 
     <artifactId>qase-java-commons</artifactId>

--- a/qase-java-commons/src/main/java/io/qase/commons/utils/CucumberUtils.java
+++ b/qase-java-commons/src/main/java/io/qase/commons/utils/CucumberUtils.java
@@ -3,6 +3,7 @@ package io.qase.commons.utils;
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
+import io.qase.commons.logger.Logger;
 
 import java.net.URI;
 import java.util.*;
@@ -11,6 +12,7 @@ import java.util.stream.Stream;
 
 
 public final class CucumberUtils {
+    private static final Logger logger = Logger.getInstance();
     private static final List<String> CASE_TAGS = Collections.unmodifiableList(Arrays.asList("@caseid", "@tmslink", "@qaseid", "@qaseids"));
     private static final String QASE_TITLE = "@QaseTitle";
     private static final String QASE_IGNORE = "@QaseIgnore";
@@ -46,7 +48,20 @@ public final class CucumberUtils {
             return null;
         }
 
-        return ids;
+        List<Long> filtered = new ArrayList<>(ids.size());
+        boolean droppedAny = false;
+        for (Long id : ids) {
+            if (id != null && id > 0) {
+                filtered.add(id);
+            } else {
+                droppedAny = true;
+            }
+        }
+        if (droppedAny) {
+            logger.warn("Ignoring non-positive Qase case id(s) in Cucumber tags: %s. Qase TestOps requires positive integer ids; the scenario will be uploaded as untagged if no valid id remains.",
+                    ids);
+        }
+        return filtered.isEmpty() ? null : filtered;
     }
 
     public static String getCaseTitle(List<String> tags) {

--- a/qase-java-commons/src/main/java/io/qase/commons/utils/IntegrationUtils.java
+++ b/qase-java-commons/src/main/java/io/qase/commons/utils/IntegrationUtils.java
@@ -1,6 +1,7 @@
 package io.qase.commons.utils;
 
 import io.qase.commons.annotation.*;
+import io.qase.commons.logger.Logger;
 import io.qase.commons.models.annotation.Field;
 
 import java.io.PrintWriter;
@@ -10,6 +11,8 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 public final class IntegrationUtils {
+    private static final Logger logger = Logger.getInstance();
+
     private IntegrationUtils() throws IllegalAccessException {
         throw new IllegalAccessException("Utils class");
     }
@@ -23,19 +26,42 @@ public final class IntegrationUtils {
     public static List<Long> getCaseIds(Method method) {
         Long qaseId = getQaseId(method);
         if (qaseId != null) {
-            return Collections.singletonList(qaseId);
+            return sanitizeCaseIds(Collections.singletonList(qaseId), method);
         }
 
         List<Long> qaseIds = getQaseIds(method);
         if (qaseIds != null) {
-            return qaseIds;
+            return sanitizeCaseIds(qaseIds, method);
         }
 
         if (method.isAnnotationPresent(CaseId.class)) {
-            return Collections.singletonList(method
-                    .getDeclaredAnnotation(CaseId.class).value());
+            return sanitizeCaseIds(Collections.singletonList(method
+                    .getDeclaredAnnotation(CaseId.class).value()), method);
         }
         return null;
+    }
+
+    static List<Long> sanitizeCaseIds(List<Long> ids, Method method) {
+        if (ids == null || ids.isEmpty()) {
+            return null;
+        }
+        List<Long> filtered = new ArrayList<>(ids.size());
+        boolean droppedAny = false;
+        for (Long id : ids) {
+            if (id != null && id > 0) {
+                filtered.add(id);
+            } else {
+                droppedAny = true;
+            }
+        }
+        if (droppedAny) {
+            String where = method != null
+                    ? method.getDeclaringClass().getName() + "." + method.getName()
+                    : "<unknown>";
+            logger.warn("Ignoring non-positive Qase case id(s) on %s: %s. Qase TestOps requires positive integer ids; the test will be uploaded as untagged if no valid id remains.",
+                    where, ids);
+        }
+        return filtered.isEmpty() ? null : filtered;
     }
 
     public static String getCaseTitle(Method method) {

--- a/qase-java-commons/src/main/java/io/qase/commons/utils/TestResultBuilder.java
+++ b/qase-java-commons/src/main/java/io/qase/commons/utils/TestResultBuilder.java
@@ -2,6 +2,7 @@ package io.qase.commons.utils;
 
 import io.qase.commons.annotation.*;
 import io.qase.commons.cucumber.CucumberTestCaseAdapter;
+import io.qase.commons.logger.Logger;
 import io.qase.commons.models.domain.Relations;
 import io.qase.commons.models.domain.SuiteData;
 import io.qase.commons.models.domain.TestResult;
@@ -29,8 +30,36 @@ import java.util.stream.Collectors;
  */
 public final class TestResultBuilder {
 
+    private static final Logger logger = Logger.getInstance();
+
     private TestResultBuilder() throws IllegalAccessException {
         throw new IllegalAccessException("Utils class");
+    }
+
+    /**
+     * Drops non-positive case ids (e.g. placeholder {@code @QaseId(0)}). Qase TestOps
+     * rejects bulk uploads where any {@code testops_ids} item is not a positive integer,
+     * and because uploads are all-or-nothing, a single placeholder would otherwise wipe
+     * the metrics of every other result in the batch.
+     */
+    static List<Long> sanitizeJUnit4CaseIds(List<Long> ids, String className, String methodName) {
+        if (ids == null || ids.isEmpty()) {
+            return ids;
+        }
+        List<Long> filtered = new ArrayList<>(ids.size());
+        boolean droppedAny = false;
+        for (Long id : ids) {
+            if (id != null && id > 0) {
+                filtered.add(id);
+            } else {
+                droppedAny = true;
+            }
+        }
+        if (droppedAny) {
+            logger.warn("Ignoring non-positive Qase case id(s) on %s.%s: %s. Qase TestOps requires positive integer ids; the test will be uploaded as untagged if no valid id remains.",
+                    className, methodName, ids);
+        }
+        return filtered.isEmpty() ? null : filtered;
     }
 
     // -------------------------------------------------------------------------
@@ -117,6 +146,7 @@ public final class TestResultBuilder {
                 caseIds = caseIdAnnotation != null ? Collections.singletonList(caseIdAnnotation.value()) : null;
             }
         }
+        caseIds = sanitizeJUnit4CaseIds(caseIds, className, methodName);
 
         // Case title: @QaseTitle → @CaseTitle (legacy) → methodName
         String caseTitle;

--- a/qase-java-commons/src/test/java/io/qase/commons/utils/CucumberUtilsTest.java
+++ b/qase-java-commons/src/test/java/io/qase/commons/utils/CucumberUtilsTest.java
@@ -65,4 +65,44 @@ class CucumberUtilsTest {
         assertNotNull(result);
         assertTrue(result.isEmpty());
     }
+
+    @Test
+    void getCaseIds_singleQaseId_returnsId() {
+        List<Long> result = CucumberUtils.getCaseIds(Arrays.asList("@QaseId=42"));
+
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals(42L, (long) result.get(0));
+    }
+
+    @Test
+    void getCaseIds_qaseIdZero_returnsNull() {
+        List<Long> result = CucumberUtils.getCaseIds(Arrays.asList("@QaseId=0"));
+
+        assertNull(result, "non-positive id must be dropped");
+    }
+
+    @Test
+    void getCaseIds_qaseIdsMixed_dropsNonPositive() {
+        List<Long> result = CucumberUtils.getCaseIds(Arrays.asList("@QaseIds=0,42,7"));
+
+        assertNotNull(result);
+        assertEquals(2, result.size());
+        assertTrue(result.contains(42L));
+        assertTrue(result.contains(7L));
+    }
+
+    @Test
+    void getCaseIds_qaseIdsAllZero_returnsNull() {
+        List<Long> result = CucumberUtils.getCaseIds(Arrays.asList("@QaseIds=0,0"));
+
+        assertNull(result);
+    }
+
+    @Test
+    void getCaseIds_noCaseTag_returnsNull() {
+        List<Long> result = CucumberUtils.getCaseIds(Arrays.asList("@QaseTitle=foo"));
+
+        assertNull(result);
+    }
 }

--- a/qase-java-commons/src/test/java/io/qase/commons/utils/IntegrationUtilsTest.java
+++ b/qase-java-commons/src/test/java/io/qase/commons/utils/IntegrationUtilsTest.java
@@ -2,9 +2,47 @@ package io.qase.commons.utils;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class IntegrationUtilsTest {
+
+    @Test
+    void sanitizeCaseIds_dropsZeroAndNegative() {
+        List<Long> result = IntegrationUtils.sanitizeCaseIds(Arrays.asList(0L, 42L, -3L, 7L), null);
+
+        assertNotNull(result);
+        assertEquals(2, result.size());
+        assertTrue(result.contains(42L));
+        assertTrue(result.contains(7L));
+    }
+
+    @Test
+    void sanitizeCaseIds_allInvalid_returnsNull() {
+        List<Long> result = IntegrationUtils.sanitizeCaseIds(Arrays.asList(0L, -1L), null);
+
+        assertNull(result);
+    }
+
+    @Test
+    void sanitizeCaseIds_emptyOrNull_returnsNull() {
+        assertNull(IntegrationUtils.sanitizeCaseIds(Collections.<Long>emptyList(), null));
+        assertNull(IntegrationUtils.sanitizeCaseIds(null, null));
+    }
+
+    @Test
+    void sanitizeCaseIds_allValid_returnsSameElements() {
+        List<Long> result = IntegrationUtils.sanitizeCaseIds(Arrays.asList(1L, 2L), null);
+
+        assertNotNull(result);
+        assertEquals(2, result.size());
+        assertEquals(1L, (long) result.get(0));
+        assertEquals(2L, (long) result.get(1));
+    }
+
 
     @Test
     void detectFrameworkVersionShouldReturnImplementationVersion() {

--- a/qase-java-commons/src/test/java/io/qase/commons/utils/TestResultBuilderTest.java
+++ b/qase-java-commons/src/test/java/io/qase/commons/utils/TestResultBuilderTest.java
@@ -28,6 +28,22 @@ class TestResultBuilderTest {
     void methodWithQaseId() {
     }
 
+    @QaseId(0)
+    void methodWithQaseIdZero() {
+    }
+
+    @QaseId(-5)
+    void methodWithQaseIdNegative() {
+    }
+
+    @QaseIds({0, 42, -1})
+    void methodWithQaseIdsMixed() {
+    }
+
+    @QaseIds({0})
+    void methodWithQaseIdsAllZero() {
+    }
+
     @QaseId(42)
     @QaseSuite("A\tB")
     void methodWithQaseIdAndSuite() {
@@ -160,6 +176,56 @@ class TestResultBuilderTest {
 
         assertNotNull(result.tags);
         assertTrue(result.tags.isEmpty());
+    }
+
+    @Test
+    void fromMethod_withQaseIdZero_dropsIdAndTreatsAsUntagged() throws Exception {
+        Method method = TestResultBuilderTest.class.getDeclaredMethod("methodWithQaseIdZero");
+        TestResult result = TestResultBuilder.fromMethod(method, Collections.<String, String>emptyMap(), 0L);
+
+        // Placeholder id must not be forwarded to the API
+        assertNull(result.testopsIds, "non-positive id must be dropped to keep batch upload safe");
+        // The test itself should still be reportable
+        assertFalse(result.ignore);
+        assertNotNull(result.title);
+    }
+
+    @Test
+    void fromMethod_withQaseIdNegative_dropsIdAndTreatsAsUntagged() throws Exception {
+        Method method = TestResultBuilderTest.class.getDeclaredMethod("methodWithQaseIdNegative");
+        TestResult result = TestResultBuilder.fromMethod(method, Collections.<String, String>emptyMap(), 0L);
+
+        assertNull(result.testopsIds);
+        assertFalse(result.ignore);
+    }
+
+    @Test
+    void fromMethod_withMixedQaseIds_keepsOnlyPositiveIds() throws Exception {
+        Method method = TestResultBuilderTest.class.getDeclaredMethod("methodWithQaseIdsMixed");
+        TestResult result = TestResultBuilder.fromMethod(method, Collections.<String, String>emptyMap(), 0L);
+
+        assertNotNull(result.testopsIds);
+        assertEquals(1, result.testopsIds.size());
+        assertEquals(42L, (long) result.testopsIds.get(0));
+    }
+
+    @Test
+    void fromMethod_withAllZeroQaseIds_dropsAllAndTreatsAsUntagged() throws Exception {
+        Method method = TestResultBuilderTest.class.getDeclaredMethod("methodWithQaseIdsAllZero");
+        TestResult result = TestResultBuilder.fromMethod(method, Collections.<String, String>emptyMap(), 0L);
+
+        assertNull(result.testopsIds);
+    }
+
+    @Test
+    void fromMethod_withQaseIdZero_signatureDoesNotContainZeroId() throws Exception {
+        Method method = TestResultBuilderTest.class.getDeclaredMethod("methodWithQaseIdZero");
+        TestResult result = TestResultBuilder.fromMethod(method, Collections.<String, String>emptyMap(), 0L);
+
+        assertNotNull(result.signature);
+        // Signature must not embed the dropped placeholder id (would otherwise differ
+        // from the signature of the same test once the real id is assigned)
+        assertFalse(result.signature.startsWith("0::"), "signature must not begin with the dropped id");
     }
 
     // -------------------------------------------------------------------------
@@ -367,6 +433,45 @@ class TestResultBuilderTest {
         assertTrue(result.tags.isEmpty());
     }
 
+    @Test
+    void fromAnnotationReader_withQaseIdZero_dropsIdAndTreatsAsUntagged() {
+        Map<Class<?>, Annotation> map = new HashMap<>();
+        map.put(QaseId.class, newQaseId(0L));
+        AnnotationReader reader = new MapAnnotationReader(map);
+
+        TestResult result = TestResultBuilder.fromAnnotationReader(reader, "com.example.MyTest", "testFoo",
+                null, 0L);
+
+        assertNull(result.testopsIds);
+        assertFalse(result.ignore);
+    }
+
+    @Test
+    void fromAnnotationReader_withQaseIdsMixed_keepsOnlyPositive() {
+        Map<Class<?>, Annotation> map = new HashMap<>();
+        map.put(QaseIds.class, newQaseIds(0L, 7L, -3L));
+        AnnotationReader reader = new MapAnnotationReader(map);
+
+        TestResult result = TestResultBuilder.fromAnnotationReader(reader, "com.example.MyTest", "testFoo",
+                null, 0L);
+
+        assertNotNull(result.testopsIds);
+        assertEquals(1, result.testopsIds.size());
+        assertEquals(7L, (long) result.testopsIds.get(0));
+    }
+
+    @Test
+    void fromAnnotationReader_withLegacyCaseIdZero_dropsIdAndTreatsAsUntagged() {
+        Map<Class<?>, Annotation> map = new HashMap<>();
+        map.put(CaseId.class, newCaseId(0L));
+        AnnotationReader reader = new MapAnnotationReader(map);
+
+        TestResult result = TestResultBuilder.fromAnnotationReader(reader, "com.example.MyTest", "testFoo",
+                null, 0L);
+
+        assertNull(result.testopsIds);
+    }
+
     // -------------------------------------------------------------------------
     // fromCucumber() tests
     // -------------------------------------------------------------------------
@@ -562,5 +667,34 @@ class TestResultBuilderTest {
 
         assertNotNull(result.tags);
         assertTrue(result.tags.isEmpty());
+    }
+
+    @Test
+    void fromCucumber_withQaseIdZero_dropsIdAndTreatsAsUntagged() {
+        StubAdapter adapter = new StubAdapter(
+                Arrays.asList("@QaseId=0"),
+                "My Scenario",
+                Arrays.asList("features", "login")
+        );
+
+        TestResult result = TestResultBuilder.fromCucumber(adapter, Collections.<String, String>emptyMap(), 0L);
+
+        assertNull(result.testopsIds);
+        assertFalse(result.ignore);
+    }
+
+    @Test
+    void fromCucumber_withQaseIdsMixed_keepsOnlyPositive() {
+        StubAdapter adapter = new StubAdapter(
+                Arrays.asList("@QaseIds=0,42"),
+                "My Scenario",
+                Arrays.asList("features", "login")
+        );
+
+        TestResult result = TestResultBuilder.fromCucumber(adapter, Collections.<String, String>emptyMap(), 0L);
+
+        assertNotNull(result.testopsIds);
+        assertEquals(1, result.testopsIds.size());
+        assertEquals(42L, (long) result.testopsIds.get(0));
     }
 }

--- a/qase-junit4-reporter/pom.xml
+++ b/qase-junit4-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.52</version>
+        <version>4.1.53</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-junit5-reporter/pom.xml
+++ b/qase-junit5-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.52</version>
+        <version>4.1.53</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-testng-reporter/pom.xml
+++ b/qase-testng-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.52</version>
+        <version>4.1.53</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
## Summary
- A single `@QaseId(0)` (or any non-positive id) made TestOps reject the whole bulk-upload batch with HTTP 422 (`testops_ids must be a positive integer`). Because uploads are all-or-nothing, every valid result in the batch was silently dropped and the run ended up empty (see #245).
- Non-positive ids from `@QaseId` / `@QaseIds` / legacy `@CaseId` are now filtered out before the signature is built and before the batch is sent. If no valid id remains, the test uploads as untagged — matching the behaviour users already expected for placeholder ids.
- A `WARN` log is emitted whenever an id is dropped, so the placeholder stays visible without needing `QASE_DEBUG=true`.

Covers all three result-construction paths:
- `IntegrationUtils.getCaseIds(Method)` — JUnit5 / TestNG
- `TestResultBuilder.fromAnnotationReader(...)` — JUnit4
- `CucumberUtils.getCaseIds(List<String>)` — Cucumber tags (`@QaseId=0`, `@QaseIds=0,42`)

Closes #245

## Test plan
- [x] `mvn -pl qase-java-commons -am test` — all 317 tests green
- [x] New unit tests for each entry point cover: single zero id, single negative id, mixed list (keeps only positives), all-non-positive list (becomes untagged), signature does not embed the dropped id
- [x] `mvn compile` — every reporter module still builds against the updated commons