### PR TITLE
fix: coerce whitespace-only param values to "empty" before batch upload

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+# qase-java 4.1.54
+
+## Bug fixes
+
+- Fixed `@ParameterizedTest` params with whitespace-only values (e.g. `"   "`, `"\t"`, `"\n"`) causing the TestOps results endpoint to reject the whole batch with HTTP 422 (`The params.* must be a string.`). Because uploads are all-or-nothing, a single blank parameter silently dropped up to 200 valid results from a run. Blank values are now coerced to `"empty"` at the same two layers that already handled `null` / `""` — `ApiClientV2.sanitizeParams()` and the defensive fallback in `ResultCreate.CustomTypeAdapterFactory.write()`. Non-blank values (including values with leading/trailing whitespace such as `" valid "`) are preserved verbatim.
+
 # qase-java 4.1.53
 
 ## Bug fixes

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.qase</groupId>
     <artifactId>qase-java</artifactId>
     <packaging>pom</packaging>
-    <version>4.1.53</version>
+    <version>4.1.54</version>
     <modules>
         <module>qase-java-commons</module>
         <module>qase-api-client</module>

--- a/qase-api-client/pom.xml
+++ b/qase-api-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.53</version>
+        <version>4.1.54</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-api-v2-client/pom.xml
+++ b/qase-api-v2-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.qase</groupId>
         <artifactId>qase-java</artifactId>
-        <version>4.1.53</version>
+        <version>4.1.54</version>
     </parent>
 
     <artifactId>qase-api-v2-client</artifactId>

--- a/qase-api-v2-client/src/main/java/io/qase/client/v2/models/ResultCreate.java
+++ b/qase-api-v2-client/src/main/java/io/qase/client/v2/models/ResultCreate.java
@@ -694,7 +694,7 @@ public class ResultCreate {
                    val = "empty";
                  } else {
                    val = entry.getValue().getAsString();
-                   if (val == null || val.isEmpty()) {
+                   if (val == null || val.trim().isEmpty()) {
                      val = "empty";
                    }
                  }

--- a/qase-cucumber-v3-reporter/pom.xml
+++ b/qase-cucumber-v3-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.53</version>
+        <version>4.1.54</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v4-reporter/pom.xml
+++ b/qase-cucumber-v4-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.53</version>
+        <version>4.1.54</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v5-reporter/pom.xml
+++ b/qase-cucumber-v5-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.53</version>
+        <version>4.1.54</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v6-reporter/pom.xml
+++ b/qase-cucumber-v6-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.53</version>
+        <version>4.1.54</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v7-reporter/pom.xml
+++ b/qase-cucumber-v7-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.53</version>
+        <version>4.1.54</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-java-commons/pom.xml
+++ b/qase-java-commons/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.qase</groupId>
         <artifactId>qase-java</artifactId>
-        <version>4.1.53</version>
+        <version>4.1.54</version>
     </parent>
 
     <artifactId>qase-java-commons</artifactId>

--- a/qase-java-commons/src/main/java/io/qase/commons/client/ApiClientV2.java
+++ b/qase-java-commons/src/main/java/io/qase/commons/client/ApiClientV2.java
@@ -278,7 +278,7 @@ public class ApiClientV2 implements ApiClient {
         Map<String, String> sanitized = new HashMap<>();
         for (Map.Entry<String, String> entry : params.entrySet()) {
             String value = entry.getValue();
-            sanitized.put(entry.getKey(), (value == null || value.isEmpty()) ? "empty" : value);
+            sanitized.put(entry.getKey(), (value == null || value.trim().isEmpty()) ? "empty" : value);
         }
         return sanitized;
     }

--- a/qase-java-commons/src/test/java/io/qase/commons/client/ParamsSerializationTest.java
+++ b/qase-java-commons/src/test/java/io/qase/commons/client/ParamsSerializationTest.java
@@ -101,6 +101,28 @@ class ParamsSerializationTest {
     }
 
     @Test
+    void blankParamsShouldSerializeAsEmpty() {
+        Map<String, String> params = new HashMap<>();
+        params.put("paramA", "   ");
+        params.put("paramB", "\t");
+        params.put("paramC", "\n");
+        params.put("paramD", " valid ");
+
+        ResultCreate result = new ResultCreate()
+                .title("test")
+                .execution(new ResultExecution().status("passed").duration(100L))
+                .params(params);
+
+        String json = JSON.serialize(result);
+        System.out.println("Blank params JSON: " + json);
+
+        assertTrue(json.contains("\"paramA\":\"empty\""), "whitespace param should become 'empty', got: " + json);
+        assertTrue(json.contains("\"paramB\":\"empty\""), "tab param should become 'empty', got: " + json);
+        assertTrue(json.contains("\"paramC\":\"empty\""), "newline param should become 'empty', got: " + json);
+        assertTrue(json.contains("\"paramD\":\" valid \""), "param with content should be preserved verbatim, got: " + json);
+    }
+
+    @Test
     void verifyDeserializeRoundtrip() {
         // Test that if we deserialize JSON with numeric-looking string params, they remain strings
         String inputJson = "{\"title\":\"test\",\"execution\":{\"status\":\"passed\",\"duration\":100}," +

--- a/qase-junit4-reporter/pom.xml
+++ b/qase-junit4-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.53</version>
+        <version>4.1.54</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-junit5-reporter/pom.xml
+++ b/qase-junit5-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.53</version>
+        <version>4.1.54</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-testng-reporter/pom.xml
+++ b/qase-testng-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.53</version>
+        <version>4.1.54</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
## Summary

- Closes #247
- Whitespace-only param values (`"   "`, `"\t"`, `"\n"`) used to slip past `sanitizeParams()` and reach the TestOps results endpoint verbatim. The API rejected them with HTTP 422 (`The params.* must be a string.`), and because batch uploads are all-or-nothing, a single blank parameter silently dropped up to 200 valid results from a run.
- Blank values are now coerced to `"empty"` at the same two layers that already handled `null` and `""`:
  - `ApiClientV2.sanitizeParams()` — `value.trim().isEmpty()` instead of `value.isEmpty()`
  - `ResultCreate.CustomTypeAdapterFactory.write()` — same coercion as defensive fallback during Gson serialization
- Java 1.8 baseline keeps us on `trim().isEmpty()` rather than `isBlank()`.
- Values with content surrounded by whitespace (e.g. `" valid "`) are preserved verbatim.
- Version bump 4.1.53 → 4.1.54 across all modules; changelog entry added.

## Test plan

- [x] Added `ParamsSerializationTest#blankParamsShouldSerializeAsEmpty` covering `"   "`, `"\t"`, `"\n"`, and `" valid "`. Verified RED → GREEN cycle.
- [x] `mvn -pl qase-java-commons test` — 322/322 pass, including the existing `nullAndEmptyParamsShouldSerializeAsEmpty` regression test.
- [x] `mvn install -DskipTests` across all 12 modules — BUILD SUCCESS.
- [ ] Optional: reproduce the original issue against a TestOps project using the minimal `@ValueSource(strings = {"", "   "})` snippet from #247 with the new build.

## Notes on the second defect in #247

The issue also raises partial-batch success (one bad record shouldn't drop the whole batch). That is a larger architectural change (per-record retry, server-side contract) and is intentionally **out of scope** for this PR — this change closes the reproducer the customer hit while we triage the broader item separately.