### PR TITLE
chore: update API clients to latest specification

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# qase-java 4.1.57
+
+- Updated API clients to the latest specification
+
 # qase-java 4.1.56
 
 - Updated API clients to the latest specification

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.qase</groupId>
     <artifactId>qase-java</artifactId>
     <packaging>pom</packaging>
-    <version>4.1.56</version>
+    <version>4.1.57</version>
     <modules>
         <module>qase-java-commons</module>
         <module>qase-api-client</module>

--- a/qase-api-client/docs/TestCase.md
+++ b/qase-api-client/docs/TestCase.md
@@ -20,8 +20,8 @@
 |**isFlaky** | **Integer** |  |  [optional] |
 |**behavior** | **Integer** |  |  [optional] |
 |**automation** | **Integer** | Deprecated, use &#x60;isManual&#x60; and &#x60;isToBeAutomated&#x60; instead. Encodes the test case automation state as a single integer: &#x60;0&#x60; &#x3D; manual, &#x60;1&#x60; &#x3D; manual planned to be automated, &#x60;2&#x60; &#x3D; automated. |  [optional] |
-|**isManual** | **Integer** | &#x60;1&#x60; if the case is manual, &#x60;0&#x60; if it is automated. Combined with &#x60;isToBeAutomated&#x60;, replaces the deprecated &#x60;automation&#x60; field. |  [optional] |
-|**isToBeAutomated** | **Integer** | &#x60;1&#x60; if a manual case is planned to be automated, &#x60;0&#x60; otherwise. Only meaningful when &#x60;isManual &#x3D; 1&#x60;; ignored when &#x60;isManual &#x3D; 0&#x60;. |  [optional] |
+|**isManual** | **Boolean** | &#x60;true&#x60; if the case is manual, &#x60;false&#x60; if it is automated. Combined with &#x60;isToBeAutomated&#x60;, replaces the deprecated &#x60;automation&#x60; field. |  [optional] |
+|**isToBeAutomated** | **Boolean** | &#x60;true&#x60; if a manual case is planned to be automated, &#x60;false&#x60; otherwise. Only meaningful when &#x60;isManual&#x60; is &#x60;true&#x60;; ignored when &#x60;isManual&#x60; is &#x60;false&#x60;. |  [optional] |
 |**status** | **Integer** |  |  [optional] |
 |**milestoneId** | **Long** |  |  [optional] |
 |**suiteId** | **Long** |  |  [optional] |

--- a/qase-api-client/docs/TestCaseCreate.md
+++ b/qase-api-client/docs/TestCaseCreate.md
@@ -20,8 +20,8 @@
 |**suiteId** | **Long** |  |  [optional] |
 |**milestoneId** | **Long** |  |  [optional] |
 |**automation** | **Integer** | Deprecated, use &#x60;isManual&#x60; and &#x60;isToBeAutomated&#x60; instead. Encodes the test case automation state as a single integer: &#x60;0&#x60; &#x3D; manual, &#x60;1&#x60; &#x3D; manual planned to be automated, &#x60;2&#x60; &#x3D; automated. If both &#x60;automation&#x60; and &#x60;isManual&#x60;/&#x60;isToBeAutomated&#x60; are provided, &#x60;isManual&#x60; and &#x60;isToBeAutomated&#x60; take precedence. |  [optional] |
-|**isManual** | **Integer** | &#x60;1&#x60; if the case is manual, &#x60;0&#x60; if it is automated. Combined with &#x60;isToBeAutomated&#x60;, replaces the deprecated &#x60;automation&#x60; field. |  [optional] |
-|**isToBeAutomated** | **Integer** | &#x60;1&#x60; if a manual case is planned to be automated, &#x60;0&#x60; otherwise. Only meaningful when &#x60;isManual &#x3D; 1&#x60;; ignored when &#x60;isManual &#x3D; 0&#x60;. |  [optional] |
+|**isManual** | **Boolean** | &#x60;true&#x60; if the case is manual, &#x60;false&#x60; if it is automated. Combined with &#x60;isToBeAutomated&#x60;, replaces the deprecated &#x60;automation&#x60; field. |  [optional] |
+|**isToBeAutomated** | **Boolean** | &#x60;true&#x60; if a manual case is planned to be automated, &#x60;false&#x60; otherwise. Only meaningful when &#x60;isManual&#x60; is &#x60;true&#x60;; ignored when &#x60;isManual&#x60; is &#x60;false&#x60;. |  [optional] |
 |**status** | **Integer** |  |  [optional] |
 |**stepsType** | [**StepsTypeEnum**](#StepsTypeEnum) | Determines the format of the steps field. When \&quot;classic\&quot;, steps use the standard action/expected_result/data format. When \&quot;gherkin\&quot;, steps use the {value: \&quot;Given...\\nWhen...\\nThen...\&quot;} format. |  [optional] |
 |**attachments** | **List&lt;String&gt;** | A list of Attachment hashes. |  [optional] |

--- a/qase-api-client/docs/TestCaseUpdate.md
+++ b/qase-api-client/docs/TestCaseUpdate.md
@@ -20,8 +20,8 @@
 |**suiteId** | **Long** |  |  [optional] |
 |**milestoneId** | **Long** |  |  [optional] |
 |**automation** | **Integer** | Deprecated, use &#x60;isManual&#x60; and &#x60;isToBeAutomated&#x60; instead. Encodes the test case automation state as a single integer: &#x60;0&#x60; &#x3D; manual, &#x60;1&#x60; &#x3D; manual planned to be automated, &#x60;2&#x60; &#x3D; automated. If both &#x60;automation&#x60; and &#x60;isManual&#x60;/&#x60;isToBeAutomated&#x60; are provided, &#x60;isManual&#x60; and &#x60;isToBeAutomated&#x60; take precedence. |  [optional] |
-|**isManual** | **Integer** | &#x60;1&#x60; if the case is manual, &#x60;0&#x60; if it is automated. Combined with &#x60;isToBeAutomated&#x60;, replaces the deprecated &#x60;automation&#x60; field. |  [optional] |
-|**isToBeAutomated** | **Integer** | &#x60;1&#x60; if a manual case is planned to be automated, &#x60;0&#x60; otherwise. Only meaningful when &#x60;isManual &#x3D; 1&#x60;; ignored when &#x60;isManual &#x3D; 0&#x60;. |  [optional] |
+|**isManual** | **Boolean** | &#x60;true&#x60; if the case is manual, &#x60;false&#x60; if it is automated. Combined with &#x60;isToBeAutomated&#x60;, replaces the deprecated &#x60;automation&#x60; field. |  [optional] |
+|**isToBeAutomated** | **Boolean** | &#x60;true&#x60; if a manual case is planned to be automated, &#x60;false&#x60; otherwise. Only meaningful when &#x60;isManual&#x60; is &#x60;true&#x60;; ignored when &#x60;isManual&#x60; is &#x60;false&#x60;. |  [optional] |
 |**status** | **Integer** |  |  [optional] |
 |**stepsType** | [**StepsTypeEnum**](#StepsTypeEnum) | Determines the format of the steps field. When \&quot;classic\&quot;, steps use the standard action/expected_result/data format. When \&quot;gherkin\&quot;, steps use the {value: \&quot;Given...\\nWhen...\\nThen...\&quot;} format. |  [optional] |
 |**attachments** | **List&lt;String&gt;** | A list of Attachment hashes. |  [optional] |

--- a/qase-api-client/docs/TestCasebulkCasesInner.md
+++ b/qase-api-client/docs/TestCasebulkCasesInner.md
@@ -20,8 +20,8 @@
 |**suiteId** | **Long** |  |  [optional] |
 |**milestoneId** | **Long** |  |  [optional] |
 |**automation** | **Integer** | Deprecated, use &#x60;isManual&#x60; and &#x60;isToBeAutomated&#x60; instead. Encodes the test case automation state as a single integer: &#x60;0&#x60; &#x3D; manual, &#x60;1&#x60; &#x3D; manual planned to be automated, &#x60;2&#x60; &#x3D; automated. If both &#x60;automation&#x60; and &#x60;isManual&#x60;/&#x60;isToBeAutomated&#x60; are provided, &#x60;isManual&#x60; and &#x60;isToBeAutomated&#x60; take precedence. |  [optional] |
-|**isManual** | **Integer** | &#x60;1&#x60; if the case is manual, &#x60;0&#x60; if it is automated. Combined with &#x60;isToBeAutomated&#x60;, replaces the deprecated &#x60;automation&#x60; field. |  [optional] |
-|**isToBeAutomated** | **Integer** | &#x60;1&#x60; if a manual case is planned to be automated, &#x60;0&#x60; otherwise. Only meaningful when &#x60;isManual &#x3D; 1&#x60;; ignored when &#x60;isManual &#x3D; 0&#x60;. |  [optional] |
+|**isManual** | **Boolean** | &#x60;true&#x60; if the case is manual, &#x60;false&#x60; if it is automated. Combined with &#x60;isToBeAutomated&#x60;, replaces the deprecated &#x60;automation&#x60; field. |  [optional] |
+|**isToBeAutomated** | **Boolean** | &#x60;true&#x60; if a manual case is planned to be automated, &#x60;false&#x60; otherwise. Only meaningful when &#x60;isManual&#x60; is &#x60;true&#x60;; ignored when &#x60;isManual&#x60; is &#x60;false&#x60;. |  [optional] |
 |**status** | **Integer** |  |  [optional] |
 |**stepsType** | [**StepsTypeEnum**](#StepsTypeEnum) | Determines the format of the steps field. When \&quot;classic\&quot;, steps use the standard action/expected_result/data format. When \&quot;gherkin\&quot;, steps use the {value: \&quot;Given...\\nWhen...\\nThen...\&quot;} format. |  [optional] |
 |**attachments** | **List&lt;String&gt;** | A list of Attachment hashes. |  [optional] |

--- a/qase-api-client/pom.xml
+++ b/qase-api-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.56</version>
+        <version>4.1.57</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-api-client/src/main/java/io/qase/client/v1/models/TestCase.java
+++ b/qase-api-client/src/main/java/io/qase/client/v1/models/TestCase.java
@@ -130,12 +130,12 @@ public class TestCase {
   public static final String SERIALIZED_NAME_IS_MANUAL = "isManual";
   @SerializedName(SERIALIZED_NAME_IS_MANUAL)
   @javax.annotation.Nullable
-  private Integer isManual;
+  private Boolean isManual;
 
   public static final String SERIALIZED_NAME_IS_TO_BE_AUTOMATED = "isToBeAutomated";
   @SerializedName(SERIALIZED_NAME_IS_TO_BE_AUTOMATED)
   @javax.annotation.Nullable
-  private Integer isToBeAutomated;
+  private Boolean isToBeAutomated;
 
   public static final String SERIALIZED_NAME_STATUS = "status";
   @SerializedName(SERIALIZED_NAME_STATUS)
@@ -538,40 +538,40 @@ public class TestCase {
   }
 
 
-  public TestCase isManual(@javax.annotation.Nullable Integer isManual) {
+  public TestCase isManual(@javax.annotation.Nullable Boolean isManual) {
     this.isManual = isManual;
     return this;
   }
 
   /**
-   * &#x60;1&#x60; if the case is manual, &#x60;0&#x60; if it is automated. Combined with &#x60;isToBeAutomated&#x60;, replaces the deprecated &#x60;automation&#x60; field.
+   * &#x60;true&#x60; if the case is manual, &#x60;false&#x60; if it is automated. Combined with &#x60;isToBeAutomated&#x60;, replaces the deprecated &#x60;automation&#x60; field.
    * @return isManual
    */
   @javax.annotation.Nullable
-  public Integer getIsManual() {
+  public Boolean getIsManual() {
     return isManual;
   }
 
-  public void setIsManual(@javax.annotation.Nullable Integer isManual) {
+  public void setIsManual(@javax.annotation.Nullable Boolean isManual) {
     this.isManual = isManual;
   }
 
 
-  public TestCase isToBeAutomated(@javax.annotation.Nullable Integer isToBeAutomated) {
+  public TestCase isToBeAutomated(@javax.annotation.Nullable Boolean isToBeAutomated) {
     this.isToBeAutomated = isToBeAutomated;
     return this;
   }
 
   /**
-   * &#x60;1&#x60; if a manual case is planned to be automated, &#x60;0&#x60; otherwise. Only meaningful when &#x60;isManual &#x3D; 1&#x60;; ignored when &#x60;isManual &#x3D; 0&#x60;.
+   * &#x60;true&#x60; if a manual case is planned to be automated, &#x60;false&#x60; otherwise. Only meaningful when &#x60;isManual&#x60; is &#x60;true&#x60;; ignored when &#x60;isManual&#x60; is &#x60;false&#x60;.
    * @return isToBeAutomated
    */
   @javax.annotation.Nullable
-  public Integer getIsToBeAutomated() {
+  public Boolean getIsToBeAutomated() {
     return isToBeAutomated;
   }
 
-  public void setIsToBeAutomated(@javax.annotation.Nullable Integer isToBeAutomated) {
+  public void setIsToBeAutomated(@javax.annotation.Nullable Boolean isToBeAutomated) {
     this.isToBeAutomated = isToBeAutomated;
   }
 

--- a/qase-api-client/src/main/java/io/qase/client/v1/models/TestCaseCreate.java
+++ b/qase-api-client/src/main/java/io/qase/client/v1/models/TestCaseCreate.java
@@ -126,12 +126,12 @@ public class TestCaseCreate {
   public static final String SERIALIZED_NAME_IS_MANUAL = "isManual";
   @SerializedName(SERIALIZED_NAME_IS_MANUAL)
   @javax.annotation.Nullable
-  private Integer isManual;
+  private Boolean isManual;
 
   public static final String SERIALIZED_NAME_IS_TO_BE_AUTOMATED = "isToBeAutomated";
   @SerializedName(SERIALIZED_NAME_IS_TO_BE_AUTOMATED)
   @javax.annotation.Nullable
-  private Integer isToBeAutomated;
+  private Boolean isToBeAutomated;
 
   public static final String SERIALIZED_NAME_STATUS = "status";
   @SerializedName(SERIALIZED_NAME_STATUS)
@@ -490,40 +490,40 @@ public class TestCaseCreate {
   }
 
 
-  public TestCaseCreate isManual(@javax.annotation.Nullable Integer isManual) {
+  public TestCaseCreate isManual(@javax.annotation.Nullable Boolean isManual) {
     this.isManual = isManual;
     return this;
   }
 
   /**
-   * &#x60;1&#x60; if the case is manual, &#x60;0&#x60; if it is automated. Combined with &#x60;isToBeAutomated&#x60;, replaces the deprecated &#x60;automation&#x60; field.
+   * &#x60;true&#x60; if the case is manual, &#x60;false&#x60; if it is automated. Combined with &#x60;isToBeAutomated&#x60;, replaces the deprecated &#x60;automation&#x60; field.
    * @return isManual
    */
   @javax.annotation.Nullable
-  public Integer getIsManual() {
+  public Boolean getIsManual() {
     return isManual;
   }
 
-  public void setIsManual(@javax.annotation.Nullable Integer isManual) {
+  public void setIsManual(@javax.annotation.Nullable Boolean isManual) {
     this.isManual = isManual;
   }
 
 
-  public TestCaseCreate isToBeAutomated(@javax.annotation.Nullable Integer isToBeAutomated) {
+  public TestCaseCreate isToBeAutomated(@javax.annotation.Nullable Boolean isToBeAutomated) {
     this.isToBeAutomated = isToBeAutomated;
     return this;
   }
 
   /**
-   * &#x60;1&#x60; if a manual case is planned to be automated, &#x60;0&#x60; otherwise. Only meaningful when &#x60;isManual &#x3D; 1&#x60;; ignored when &#x60;isManual &#x3D; 0&#x60;.
+   * &#x60;true&#x60; if a manual case is planned to be automated, &#x60;false&#x60; otherwise. Only meaningful when &#x60;isManual&#x60; is &#x60;true&#x60;; ignored when &#x60;isManual&#x60; is &#x60;false&#x60;.
    * @return isToBeAutomated
    */
   @javax.annotation.Nullable
-  public Integer getIsToBeAutomated() {
+  public Boolean getIsToBeAutomated() {
     return isToBeAutomated;
   }
 
-  public void setIsToBeAutomated(@javax.annotation.Nullable Integer isToBeAutomated) {
+  public void setIsToBeAutomated(@javax.annotation.Nullable Boolean isToBeAutomated) {
     this.isToBeAutomated = isToBeAutomated;
   }
 

--- a/qase-api-client/src/main/java/io/qase/client/v1/models/TestCaseUpdate.java
+++ b/qase-api-client/src/main/java/io/qase/client/v1/models/TestCaseUpdate.java
@@ -126,12 +126,12 @@ public class TestCaseUpdate {
   public static final String SERIALIZED_NAME_IS_MANUAL = "isManual";
   @SerializedName(SERIALIZED_NAME_IS_MANUAL)
   @javax.annotation.Nullable
-  private Integer isManual;
+  private Boolean isManual;
 
   public static final String SERIALIZED_NAME_IS_TO_BE_AUTOMATED = "isToBeAutomated";
   @SerializedName(SERIALIZED_NAME_IS_TO_BE_AUTOMATED)
   @javax.annotation.Nullable
-  private Integer isToBeAutomated;
+  private Boolean isToBeAutomated;
 
   public static final String SERIALIZED_NAME_STATUS = "status";
   @SerializedName(SERIALIZED_NAME_STATUS)
@@ -480,40 +480,40 @@ public class TestCaseUpdate {
   }
 
 
-  public TestCaseUpdate isManual(@javax.annotation.Nullable Integer isManual) {
+  public TestCaseUpdate isManual(@javax.annotation.Nullable Boolean isManual) {
     this.isManual = isManual;
     return this;
   }
 
   /**
-   * &#x60;1&#x60; if the case is manual, &#x60;0&#x60; if it is automated. Combined with &#x60;isToBeAutomated&#x60;, replaces the deprecated &#x60;automation&#x60; field.
+   * &#x60;true&#x60; if the case is manual, &#x60;false&#x60; if it is automated. Combined with &#x60;isToBeAutomated&#x60;, replaces the deprecated &#x60;automation&#x60; field.
    * @return isManual
    */
   @javax.annotation.Nullable
-  public Integer getIsManual() {
+  public Boolean getIsManual() {
     return isManual;
   }
 
-  public void setIsManual(@javax.annotation.Nullable Integer isManual) {
+  public void setIsManual(@javax.annotation.Nullable Boolean isManual) {
     this.isManual = isManual;
   }
 
 
-  public TestCaseUpdate isToBeAutomated(@javax.annotation.Nullable Integer isToBeAutomated) {
+  public TestCaseUpdate isToBeAutomated(@javax.annotation.Nullable Boolean isToBeAutomated) {
     this.isToBeAutomated = isToBeAutomated;
     return this;
   }
 
   /**
-   * &#x60;1&#x60; if a manual case is planned to be automated, &#x60;0&#x60; otherwise. Only meaningful when &#x60;isManual &#x3D; 1&#x60;; ignored when &#x60;isManual &#x3D; 0&#x60;.
+   * &#x60;true&#x60; if a manual case is planned to be automated, &#x60;false&#x60; otherwise. Only meaningful when &#x60;isManual&#x60; is &#x60;true&#x60;; ignored when &#x60;isManual&#x60; is &#x60;false&#x60;.
    * @return isToBeAutomated
    */
   @javax.annotation.Nullable
-  public Integer getIsToBeAutomated() {
+  public Boolean getIsToBeAutomated() {
     return isToBeAutomated;
   }
 
-  public void setIsToBeAutomated(@javax.annotation.Nullable Integer isToBeAutomated) {
+  public void setIsToBeAutomated(@javax.annotation.Nullable Boolean isToBeAutomated) {
     this.isToBeAutomated = isToBeAutomated;
   }
 

--- a/qase-api-client/src/main/java/io/qase/client/v1/models/TestCasebulkCasesInner.java
+++ b/qase-api-client/src/main/java/io/qase/client/v1/models/TestCasebulkCasesInner.java
@@ -126,12 +126,12 @@ public class TestCasebulkCasesInner {
   public static final String SERIALIZED_NAME_IS_MANUAL = "isManual";
   @SerializedName(SERIALIZED_NAME_IS_MANUAL)
   @javax.annotation.Nullable
-  private Integer isManual;
+  private Boolean isManual;
 
   public static final String SERIALIZED_NAME_IS_TO_BE_AUTOMATED = "isToBeAutomated";
   @SerializedName(SERIALIZED_NAME_IS_TO_BE_AUTOMATED)
   @javax.annotation.Nullable
-  private Integer isToBeAutomated;
+  private Boolean isToBeAutomated;
 
   public static final String SERIALIZED_NAME_STATUS = "status";
   @SerializedName(SERIALIZED_NAME_STATUS)
@@ -495,40 +495,40 @@ public class TestCasebulkCasesInner {
   }
 
 
-  public TestCasebulkCasesInner isManual(@javax.annotation.Nullable Integer isManual) {
+  public TestCasebulkCasesInner isManual(@javax.annotation.Nullable Boolean isManual) {
     this.isManual = isManual;
     return this;
   }
 
   /**
-   * &#x60;1&#x60; if the case is manual, &#x60;0&#x60; if it is automated. Combined with &#x60;isToBeAutomated&#x60;, replaces the deprecated &#x60;automation&#x60; field.
+   * &#x60;true&#x60; if the case is manual, &#x60;false&#x60; if it is automated. Combined with &#x60;isToBeAutomated&#x60;, replaces the deprecated &#x60;automation&#x60; field.
    * @return isManual
    */
   @javax.annotation.Nullable
-  public Integer getIsManual() {
+  public Boolean getIsManual() {
     return isManual;
   }
 
-  public void setIsManual(@javax.annotation.Nullable Integer isManual) {
+  public void setIsManual(@javax.annotation.Nullable Boolean isManual) {
     this.isManual = isManual;
   }
 
 
-  public TestCasebulkCasesInner isToBeAutomated(@javax.annotation.Nullable Integer isToBeAutomated) {
+  public TestCasebulkCasesInner isToBeAutomated(@javax.annotation.Nullable Boolean isToBeAutomated) {
     this.isToBeAutomated = isToBeAutomated;
     return this;
   }
 
   /**
-   * &#x60;1&#x60; if a manual case is planned to be automated, &#x60;0&#x60; otherwise. Only meaningful when &#x60;isManual &#x3D; 1&#x60;; ignored when &#x60;isManual &#x3D; 0&#x60;.
+   * &#x60;true&#x60; if a manual case is planned to be automated, &#x60;false&#x60; otherwise. Only meaningful when &#x60;isManual&#x60; is &#x60;true&#x60;; ignored when &#x60;isManual&#x60; is &#x60;false&#x60;.
    * @return isToBeAutomated
    */
   @javax.annotation.Nullable
-  public Integer getIsToBeAutomated() {
+  public Boolean getIsToBeAutomated() {
     return isToBeAutomated;
   }
 
-  public void setIsToBeAutomated(@javax.annotation.Nullable Integer isToBeAutomated) {
+  public void setIsToBeAutomated(@javax.annotation.Nullable Boolean isToBeAutomated) {
     this.isToBeAutomated = isToBeAutomated;
   }
 

--- a/qase-api-v2-client/pom.xml
+++ b/qase-api-v2-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.qase</groupId>
         <artifactId>qase-java</artifactId>
-        <version>4.1.56</version>
+        <version>4.1.57</version>
     </parent>
 
     <artifactId>qase-api-v2-client</artifactId>

--- a/qase-cucumber-v3-reporter/pom.xml
+++ b/qase-cucumber-v3-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.56</version>
+        <version>4.1.57</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v4-reporter/pom.xml
+++ b/qase-cucumber-v4-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.56</version>
+        <version>4.1.57</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v5-reporter/pom.xml
+++ b/qase-cucumber-v5-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.56</version>
+        <version>4.1.57</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v6-reporter/pom.xml
+++ b/qase-cucumber-v6-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.56</version>
+        <version>4.1.57</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-cucumber-v7-reporter/pom.xml
+++ b/qase-cucumber-v7-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.56</version>
+        <version>4.1.57</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-java-commons/pom.xml
+++ b/qase-java-commons/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.qase</groupId>
         <artifactId>qase-java</artifactId>
-        <version>4.1.56</version>
+        <version>4.1.57</version>
     </parent>
 
     <artifactId>qase-java-commons</artifactId>

--- a/qase-junit4-reporter/pom.xml
+++ b/qase-junit4-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.56</version>
+        <version>4.1.57</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-junit5-reporter/pom.xml
+++ b/qase-junit5-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.56</version>
+        <version>4.1.57</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qase-testng-reporter/pom.xml
+++ b/qase-testng-reporter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>qase-java</artifactId>
         <groupId>io.qase</groupId>
-        <version>4.1.56</version>
+        <version>4.1.57</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
## Summary

- Updated API clients to the latest OpenAPI specification

### Targets updated:
- v1 (`qase-api-client`): version cascade 4.1.56 → 4.1.57 (root + all modules)

### Change
`isManual` and `isToBeAutomated` on `TestCase` / `TestCaseCreate` / `TestCaseUpdate` are now typed as `Boolean` (was `Integer`), matching the actual API response (JSON booleans).

### Protected files (skipped):
- `ApiClient.java`

### Warnings:
None